### PR TITLE
Use bigger max image resolution

### DIFF
--- a/src/cctag/Types.cpp
+++ b/src/cctag/Types.cpp
@@ -21,7 +21,7 @@ EdgePointCollection::EdgePointCollection(size_t w, size_t h) :
   _processedAux(new unsigned[MAX_POINTS/4])
 {
   if (w > MAX_RESOLUTION || h > MAX_RESOLUTION)
-    throw std::length_error("EdgePointCollection::set_frame_size: dimension too large");
+    throw std::length_error("EdgePointCollection::set_frame_size: image resolution is too large");
 
   point_count() = 0;
   _edgeMapShape[0] = w; _edgeMapShape[1] = h;

--- a/src/cctag/Types.hpp
+++ b/src/cctag/Types.hpp
@@ -19,7 +19,7 @@ namespace cctag {
 class EdgePointCollection
 {
   static constexpr size_t MAX_POINTS = size_t(1) << 20;
-  static constexpr size_t MAX_RESOLUTION = 5120;
+  static constexpr size_t MAX_RESOLUTION = 6144;
   static constexpr size_t CUDA_OFFSET = 1024; // 4 kB, one page
   static constexpr size_t MAX_VOTERLIST_SIZE = 16*MAX_POINTS;
   


### PR DESCRIPTION
I use a bigger max image resolution to support standard DSLR cameras before we found a solution to remove this limitation.
