### PR TITLE
[cmake] fix for cmake < 3.6

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,7 +95,7 @@ if(WITH_CUDA)
   # this must go before CUDA_ADD_LIBRARY otherwise we won't be able to add it
   # after
   # https://github.com/Kitware/CMake/blob/master/Modules/FindCUDA.cmake#L147
-  INCLUDE_DIRECTORIES("$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>" 
+  include_directories(${CMAKE_CURRENT_LIST_DIR}
                       ${Boost_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${Eigen_INCLUDE_DIR} ${TBB_INCLUDE_DIRS}
                       "${CMAKE_SOURCE_DIR}/3rdparty/Cuda-7.0-cub")
  


### PR DESCRIPTION
generator expressions seems not to be handled correctly in older versions of cmake (eg 3.5) inside`include_directories` (ie it sends at command line the whole expression without first resolving it, thus causing the building to fail).

In any case it was not necessary as the `set_target_properties()` that comes next will properly set the includes to propagate. This is on me, it must have slipped through the tests i made when refactoring the cmakelists.