### PR TITLE
[cctag] fix include for boost 1.64

### DIFF
--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -21,7 +21,7 @@
 #include <cctag/utils/VisualDebug.hpp>
 
 #include <boost/foreach.hpp>
-#include <boost/format/format_implementation.hpp>
+#include <boost/format.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/log1p.hpp>


### PR DESCRIPTION
When compiling with boost 1.64 (and clang 3.9) some errors are raised:
```
In file included from CCTag/src/cctag/Vote.cpp:24:
/usr/local/include/boost/format/format_implementation.hpp:166:44: error: no member named 'out_of_range' in namespace 'boost::io'
                boost::throw_exception(io::out_of_range(argN, 1, num_args_+1 ) ); 
                                       ~~~~^
/usr/local/include/boost/format/format_implementation.hpp:224:44: error: no member named 'too_few_args' in namespace 'boost::io'; did you mean 'too_few_args_bit'?
                boost::throw_exception(io::too_few_args(cur_arg_, num_args_)); 
                                       ~~~~^
/usr/local/include/boost/format/format_fwd.hpp:35:34: note: 'too_few_args_bit' declared here
                                 too_few_args_bit = 2, too_many_args_bit = 4,
                                 ^
In file included from CCTag/src/cctag/Vote.cpp:24:
/usr/local/include/boost/format/format_implementation.hpp:283:44: error: no member named 'out_of_range' in namespace 'boost::io'
                boost::throw_exception(io::out_of_range(argN, 1, self.num_args_+1 ) );
                                       ~~~~^
/usr/local/include/boost/format/format_implementation.hpp:316:44: error: no member named 'out_of_range' in namespace 'boost::io'
                boost::throw_exception(io::out_of_range(itemN, 1, static_cast<int>(self.items_.size()) ));
                                       ~~~~^
```

Apparently we need to include the general header `format.hpp` instead of the specific headers (eg `format_implementation.hpp`).

That's what this PR does