### PR TITLE
C++11 Modernizing, cleaning and fixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,7 +181,13 @@ script:
 after_success:
   - du -hs $OPENCV_INSTALL
 
+# Before uploading the new cache archive
+before_cache:
+  - ccache -s
+
 cache:
+  ccache: true
+
   directories:
     - $OPENCV_INSTALL
     - $CMAKE_INSTALL

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -41,5 +41,8 @@
 
 include(CMakeFindDependencyMacro)
 
+set(OpenCV_DIR @OpenCV_DIR@)
+find_dependency(OpenCV)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -79,7 +79,7 @@ bool CmdLine::parse( int argc, char* argv[] )
       default : break;
     }
   }
-  return ( has_i & has_n );
+  return ( has_i && has_n );
 }
 
 void CmdLine::print( const char* const argv0 )

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -128,7 +128,7 @@ void detection(std::size_t frameId,
   CCTagVisualDebug::instance().setImageFileName(debugFileName);
   CCTagFileDebug::instance().setPath(CCTagVisualDebug::instance().getPath());
 
-  static cctag::logtime::Mgmt* durations = 0;
+  static cctag::logtime::Mgmt* durations = nullptr;
 
   //Call the main CCTag detection function
   cctagDetection(markers, pipeId, frameId, src, params, bank, true, durations);

--- a/src/applications/regression/Regression.cpp
+++ b/src/applications/regression/Regression.cpp
@@ -8,8 +8,8 @@
 #include <algorithm>
 #include "Regression.h"
 
-static void RemoveAllFiles(const boost::filesystem::path dirPath);
-static std::vector<boost::filesystem::path> CollectFiles(const boost::filesystem::path dirPath);
+static void RemoveAllFiles(const boost::filesystem::path& dirPath);
+static std::vector<boost::filesystem::path> CollectFiles(const boost::filesystem::path& dirPath);
 static bool SortTags(FrameLog& log);
 
 /////////////////////////////////////////////////////////////////////////////
@@ -171,14 +171,14 @@ void TestChecker::compare(const DetectedTag& referenceTag, const DetectedTag& te
 
 /////////////////////////////////////////////////////////////////////////////
 
-static void RemoveAllFiles(const boost::filesystem::path dirPath)
+static void RemoveAllFiles(const boost::filesystem::path& dirPath)
 {
   using namespace boost::filesystem;
   remove_all(dirPath);
   create_directories(dirPath);
 }
 
-static std::vector<boost::filesystem::path> CollectFiles(const boost::filesystem::path dirPath)
+static std::vector<boost::filesystem::path> CollectFiles(const boost::filesystem::path& dirPath)
 {
   using namespace boost::filesystem;
   std::vector<path> filePaths;

--- a/src/applications/regression/Regression.h
+++ b/src/applications/regression/Regression.h
@@ -43,7 +43,7 @@ class TestChecker
   
   struct check_error : public std::runtime_error
   {
-    check_error(const std::string& what) : runtime_error(what)
+    explicit check_error(const std::string& what) : runtime_error(what)
     { }
   };
 

--- a/src/applications/regression/TestLog.cpp
+++ b/src/applications/regression/TestLog.cpp
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-#include <math.h>
+#include <cmath>
 #include <fstream>
 #include <chrono>
 #include <stdexcept>

--- a/src/applications/regression/TestLog.h
+++ b/src/applications/regression/TestLog.h
@@ -32,7 +32,7 @@ struct DetectedTag
   DetectedTag() = default;
   
   // NB: we DO want implicit conversion for easy conversion of containers of CCTags
-  DetectedTag(const cctag::CCTag& marker) :
+  explicit DetectedTag(const cctag::CCTag& marker) :
     id(marker.id()), status(marker.getStatus()),
     x(marker.x()), y(marker.y()), quality(marker.quality())
   { }

--- a/src/applications/regression/main.cpp
+++ b/src/applications/regression/main.cpp
@@ -123,18 +123,18 @@ int main(int argc, char **argv)
     
     if (mode == "gen-ref") {
       GenerateReference();
-      return 0;
+      return EXIT_SUCCESS;
     }
     
     if (mode == "gen-test") {
       TestRunner testRunner(SourceDir, DestinationDir, UseCuda);
       testRunner.generateTestResults();
-      return 0;
+      return EXIT_SUCCESS;
     }
     
     if (mode == "compare") {
       bool ok = ReportChecks();
-      return ok ? 0 : 1;
+      return ok ? EXIT_SUCCESS : EXIT_FAILURE;
     }
     
     throw std::logic_error("internal error: invalid mode");
@@ -146,6 +146,6 @@ int main(int argc, char **argv)
   catch (std::exception& e) {
     std::cerr << "FATAL ERROR: " << e.what() << std::endl;
   }
-  return 1;
+  return EXIT_FAILURE;
 }
 

--- a/src/cctag/Bresenham.cpp
+++ b/src/cctag/Bresenham.cpp
@@ -40,7 +40,7 @@ EdgePoint* gradientDirectionDescent(
         const cv::Mat & imgDy, 
         int thrGradient)
 {
-    EdgePoint* ret = NULL;
+    EdgePoint* ret = nullptr;
     float e        = 0.0f;
     float dx       = dir * imgDx.at<short>(p.y(),p.x());
     float dy       = dir * imgDy.at<short>(p.y(),p.x());
@@ -96,7 +96,7 @@ EdgePoint* gradientDirectionDescent(
         }
         else
         {
-                return NULL;
+                return nullptr;
         }
 
         while( n <= nmax)
@@ -126,13 +126,13 @@ EdgePoint* gradientDirectionDescent(
                     }
                     else
                     {
-                            return NULL;
+                            return nullptr;
                     }
                 }
             }
             else
             {
-                    return NULL;
+                    return nullptr;
             }
         }
     }
@@ -166,7 +166,7 @@ EdgePoint* gradientDirectionDescent(
         }
         else
         {
-            return NULL;
+            return nullptr;
         }
 
         while( n <= nmax)
@@ -196,17 +196,17 @@ EdgePoint* gradientDirectionDescent(
                     }
                     else
                     {
-                        return NULL;
+                        return nullptr;
                     }
                 }
             }
             else
             {
-                return NULL;
+                return nullptr;
             }
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 } // namespace cctag

--- a/src/cctag/Bresenham.cpp
+++ b/src/cctag/Bresenham.cpp
@@ -35,7 +35,7 @@ EdgePoint* gradientDirectionDescent(
         const EdgePointCollection& canny,
         const EdgePoint& p,
         int dir,
-        const std::size_t nmax, 
+        std::size_t nmax,
         const cv::Mat & imgDx, 
         const cv::Mat & imgDy, 
         int thrGradient)

--- a/src/cctag/Bresenham.hpp
+++ b/src/cctag/Bresenham.hpp
@@ -27,8 +27,8 @@ class EdgePoint;
 EdgePoint* gradientDirectionDescent(
   const EdgePointCollection& canny,
   const EdgePoint& p,
-  const int dir,
-  const std::size_t nmax,
+  int dir,
+  std::size_t nmax,
   const cv::Mat & dx, 
   const cv::Mat & dy,
   int thrGradient);

--- a/src/cctag/Bresenham.hpp
+++ b/src/cctag/Bresenham.hpp
@@ -29,8 +29,8 @@ EdgePoint* gradientDirectionDescent(
   const EdgePoint& p,
   int dir,
   std::size_t nmax,
-  const cv::Mat & dx, 
-  const cv::Mat & dy,
+  const cv::Mat & imgDx,
+  const cv::Mat & imgDy,
   int thrGradient);
 
 } // namespace cctag

--- a/src/cctag/CCTag.cpp
+++ b/src/cctag/CCTag.cpp
@@ -73,13 +73,13 @@ void CCTag::condition(const Eigen::Matrix3f & mT, const Eigen::Matrix3f & mInvT)
   cctag::numerical::normalizeDet1(_outerEllipse.matrix());
 
   // Condition all ellipses
-  BOOST_FOREACH(cctag::numerical::geometry::Ellipse & ellipse, _ellipses)
+  for(cctag::numerical::geometry::Ellipse & ellipse : _ellipses)
   {
     ellipse = ellipse.transform(mInvT);
     cctag::numerical::normalizeDet1(ellipse.matrix());
   }
 
-  BOOST_FOREACH(std::vector<cctag::DirectedPoint2d<Eigen::Vector3f> > & points, _points)
+  for(std::vector<cctag::DirectedPoint2d<Eigen::Vector3f> > & points : _points)
   {
     cctag::numerical::optimization::condition(points, mT);
   }
@@ -90,10 +90,10 @@ void CCTag::condition(const Eigen::Matrix3f & mT, const Eigen::Matrix3f & mInvT)
 void CCTag::scale(const float s)
 {
 
-  BOOST_FOREACH(std::vector< DirectedPoint2d<Eigen::Vector3f> > &vp, _points)
+  for(std::vector< DirectedPoint2d<Eigen::Vector3f> > &vp : _points)
   {
 
-    BOOST_FOREACH(DirectedPoint2d<Eigen::Vector3f> & p, vp)
+    for(DirectedPoint2d<Eigen::Vector3f> & p : vp)
     {
       p.x() = p.x() * s;
       p.y() = p.y() * s;

--- a/src/cctag/CCTag.cpp
+++ b/src/cctag/CCTag.cpp
@@ -87,7 +87,7 @@ void CCTag::condition(const Eigen::Matrix3f & mT, const Eigen::Matrix3f & mInvT)
   cctag::numerical::optimization::condition(_centerImg, mT);
 }
 
-void CCTag::scale(const float s)
+void CCTag::scale(float s)
 {
 
   for(std::vector< DirectedPoint2d<Eigen::Vector3f> > &vp : _points)
@@ -121,7 +121,7 @@ void CCTag::releaseNearbyPointMemory( int tagId )
 }
 #endif
 
-void CCTag::serialize(boost::archive::text_oarchive & ar, const unsigned int version)
+void CCTag::serialize(boost::archive::text_oarchive & ar, unsigned int version)
 {
   ar & BOOST_SERIALIZATION_NVP(_nCircles);
   ar & BOOST_SERIALIZATION_NVP(_id);

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -118,7 +118,7 @@ public:
   void printTag( std::ostream& ostr ) const;
 #endif
 
-  void scale(const float s);
+  void scale(float s);
 
   float x() const override {
     return _centerImg.x();
@@ -363,7 +363,7 @@ public:
   static void releaseNearbyPointMemory( int pipeId );
 #endif
 
-  void serialize(boost::archive::text_oarchive & ar, const unsigned int version);
+  void serialize(boost::archive::text_oarchive & ar, unsigned int version);
 
 protected:
 

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -56,7 +56,7 @@ public:
     , _quality(0)
     , _status(0)
 #ifdef WITH_CUDA
-    , _cuda_result( 0 )
+    , _cuda_result( nullptr )
 #endif
   {
     setInitRadius();
@@ -79,7 +79,7 @@ public:
     , _pyramidLevel(pyramidLevel)
     , _scale(scale)
 #ifdef WITH_CUDA
-    , _cuda_result( 0 )
+    , _cuda_result( nullptr )
 #endif
   {
     setInitRadius();
@@ -104,7 +104,7 @@ public:
     , _rescaledOuterEllipse(cctag._rescaledOuterEllipse)
     , _status(cctag._status)
 #ifdef WITH_CUDA
-    , _cuda_result( 0 )
+    , _cuda_result( nullptr )
 #endif
 #ifdef CCTAG_SERIALIZE
     , _flowComponents(cctag._flowComponents)
@@ -112,9 +112,7 @@ public:
   {
   }
 
-  ~CCTag() override
-  {
-  }
+  virtual ~CCTag() = default;
 
 #ifndef NDEBUG
   void printTag( std::ostream& ostr ) const;

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -46,8 +46,8 @@ typedef std::vector< std::pair< MarkerID, float > > IdSet;
 class CCTag : public ICCTag
 {
 public:
-  typedef boost::ptr_vector<CCTag> Vector;
-  typedef boost::ptr_list<CCTag> List;
+  using Vector = boost::ptr_vector<CCTag>;
+  using List = boost::ptr_list<CCTag>;
 
 public:
 

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -112,7 +112,7 @@ public:
   {
   }
 
-  virtual ~CCTag()
+  ~CCTag() override
   {
   }
 
@@ -122,11 +122,11 @@ public:
 
   void scale(const float s);
 
-  float x() const {
+  float x() const override {
     return _centerImg.x();
   }
   
-  float y() const {
+  float y() const override {
     return _centerImg.y();
   }
   
@@ -260,7 +260,7 @@ public:
     return true;
   }
 
-  MarkerID id() const
+  MarkerID id() const override
   {
     return _id;
   }
@@ -280,7 +280,7 @@ public:
     _idSet = idSet;
   }
 
-  int getStatus() const
+  int getStatus() const override
   {
     return _status;
   }
@@ -298,7 +298,7 @@ public:
 
   //friend std::ostream& operator<<(std::ostream& os, const CCTag& cm);
 
-  inline CCTag* clone() const
+  inline CCTag* clone() const override
   {
     return new CCTag(*this);
   }

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -316,8 +316,7 @@ public:
 
   void addFlowComponent(const Candidate & candidate, const EdgePointCollection& edgeCollection)
   {
-    _flowComponents.push_back(
-      CCTagFlowComponent(
+    _flowComponents.emplace_back(
         edgeCollection,
         candidate._outerEllipsePoints,
         candidate._childrens,
@@ -325,7 +324,7 @@ public:
         candidate._outerEllipse,
         candidate._convexEdgeSegment,
         *(candidate._seed),
-        _nCircles));
+        _nCircles);
   }
 
   void setFlowComponents(const std::vector<CCTagFlowComponent> & flowComponents)

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -317,8 +317,8 @@ public:
     _flowComponents.emplace_back(
         edgeCollection,
         candidate._outerEllipsePoints,
-        candidate._childrens,
-        candidate._filteredChildrens,
+        candidate._children,
+        candidate._filteredChildren,
         candidate._outerEllipse,
         candidate._convexEdgeSegment,
         *(candidate._seed),

--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -335,7 +335,7 @@ public:
 
   void setFlowComponents(const std::vector<Candidate> & candidates, const EdgePointCollection& edgeCollection)
   {
-    BOOST_FOREACH(const Candidate & candidate, candidates)
+    for(const Candidate & candidate : candidates)
     {
       addFlowComponent(candidate, edgeCollection);
     }

--- a/src/cctag/CCTagFlowComponent.cpp
+++ b/src/cctag/CCTagFlowComponent.cpp
@@ -31,12 +31,12 @@ CCTagFlowComponent::CCTagFlowComponent(
 
   for(const EdgePoint * e : outerEllipsePoints)
   {
-    _outerEllipsePoints.push_back(EdgePoint(*e));
+    _outerEllipsePoints.emplace_back(*e);
   }
 
   for(const EdgePoint * e : convexEdgeSegment)
   {
-    _convexEdgeSegment.push_back(EdgePoint(*e));
+    _convexEdgeSegment.emplace_back(*e);
   }
 
   setFieldLines(childrens, edgeCollection);
@@ -50,15 +50,13 @@ void CCTagFlowComponent::setFilteredFieldLines(const std::vector<EdgePoint*> & f
 
   std::size_t i = 0;
 
-  for (std::vector<EdgePoint*>::const_iterator it = filteredChildrens.begin(); it != filteredChildrens.end(); ++it)
+  for(auto p : filteredChildrens)
   {
     int dir = -1;
-    EdgePoint* p = *it;
-
     std::vector<EdgePoint> & vE = _filteredFieldLines[i];
 
     vE.reserve(_nCircles);
-    vE.push_back(EdgePoint(*p));
+    vE.emplace_back(*p);
 
     for (std::size_t j = 1; j < _nCircles; ++j)
     {
@@ -71,7 +69,7 @@ void CCTagFlowComponent::setFilteredFieldLines(const std::vector<EdgePoint*> & f
         p = edgeCollection.after(p);
       }
 
-      vE.push_back(EdgePoint(*p));
+      vE.emplace_back(*p);
 
       dir = -dir;
     }
@@ -94,7 +92,7 @@ void CCTagFlowComponent::setFieldLines(const std::list<EdgePoint*> & childrens, 
     std::vector<EdgePoint> & vE = _fieldLines[i];
 
     vE.reserve(_nCircles);
-    vE.push_back(EdgePoint(*p));
+    vE.emplace_back(*p);
 
     for (std::size_t j = 1; j < _nCircles; ++j)
     {
@@ -108,7 +106,7 @@ void CCTagFlowComponent::setFieldLines(const std::list<EdgePoint*> & childrens, 
       }
 
       assert( p );
-      vE.push_back(EdgePoint(*p));
+      vE.emplace_back(*p);
 
       dir = -dir;
     }

--- a/src/cctag/CCTagFlowComponent.cpp
+++ b/src/cctag/CCTagFlowComponent.cpp
@@ -16,8 +16,8 @@ namespace cctag
 CCTagFlowComponent::CCTagFlowComponent(
   const EdgePointCollection& edgeCollection,
   const std::vector<EdgePoint*> & outerEllipsePoints,
-  const std::list<EdgePoint*> & childrens,
-  const std::vector<EdgePoint*> & filteredChildrens,
+  const std::list<EdgePoint*> & children,
+  const std::vector<EdgePoint*> & filteredChildren,
   const cctag::numerical::geometry::Ellipse & outerEllipse,
   const std::list<EdgePoint*> & convexEdgeSegment,
   const EdgePoint & seed,
@@ -39,18 +39,18 @@ CCTagFlowComponent::CCTagFlowComponent(
     _convexEdgeSegment.emplace_back(*e);
   }
 
-  setFieldLines(childrens, edgeCollection);
-  setFilteredFieldLines(filteredChildrens, edgeCollection);
+  setFieldLines(children, edgeCollection);
+  setFilteredFieldLines(filteredChildren, edgeCollection);
 
 }
 
-void CCTagFlowComponent::setFilteredFieldLines(const std::vector<EdgePoint*> & filteredChildrens, const EdgePointCollection& edgeCollection)
+void CCTagFlowComponent::setFilteredFieldLines(const std::vector<EdgePoint*> & filteredChildren, const EdgePointCollection& edgeCollection)
 {
-  _filteredFieldLines.resize(filteredChildrens.size());
+  _filteredFieldLines.resize(filteredChildren.size());
 
   std::size_t i = 0;
 
-  for(auto p : filteredChildrens)
+  for(auto p : filteredChildren)
   {
     int dir = -1;
     std::vector<EdgePoint> & vE = _filteredFieldLines[i];
@@ -77,13 +77,13 @@ void CCTagFlowComponent::setFilteredFieldLines(const std::vector<EdgePoint*> & f
   }
 }
 
-void CCTagFlowComponent::setFieldLines(const std::list<EdgePoint*> & childrens, const EdgePointCollection& edgeCollection)
+void CCTagFlowComponent::setFieldLines(const std::list<EdgePoint*> & children, const EdgePointCollection& edgeCollection)
 {
-  _fieldLines.resize(childrens.size());
+  _fieldLines.resize(children.size());
 
   std::size_t i = 0;
 
-  for (std::list<EdgePoint*>::const_iterator it = childrens.begin(); it != childrens.end(); ++it)
+  for (std::list<EdgePoint*>::const_iterator it = children.begin(); it != children.end(); ++it)
   {
     int dir = -1;
     EdgePoint* p = *it;

--- a/src/cctag/CCTagFlowComponent.cpp
+++ b/src/cctag/CCTagFlowComponent.cpp
@@ -29,12 +29,12 @@ CCTagFlowComponent::CCTagFlowComponent(
 
   _outerEllipsePoints.reserve(outerEllipsePoints.size());
 
-  BOOST_FOREACH(const EdgePoint * e, outerEllipsePoints)
+  for(const EdgePoint * e : outerEllipsePoints)
   {
     _outerEllipsePoints.push_back(EdgePoint(*e));
   }
 
-  BOOST_FOREACH(const EdgePoint * e, convexEdgeSegment)
+  for(const EdgePoint * e : convexEdgeSegment)
   {
     _convexEdgeSegment.push_back(EdgePoint(*e));
   }

--- a/src/cctag/CCTagFlowComponent.hpp
+++ b/src/cctag/CCTagFlowComponent.hpp
@@ -27,15 +27,15 @@ public:
 
   CCTagFlowComponent(const EdgePointCollection& edgeCollection,
                      const std::vector<EdgePoint*> & outerEllipsePoints,
-                     const std::list<EdgePoint*> & childrens,
-                     const std::vector<EdgePoint*> & filteredChildrens,
+                     const std::list<EdgePoint*> & children,
+                     const std::vector<EdgePoint*> & filteredChildren,
                      const cctag::numerical::geometry::Ellipse & outerEllipse,
                      const std::list<EdgePoint*> & convexEdgeSegment,
                      const EdgePoint & seed,
                      std::size_t nCircles);
 
-  void setFieldLines(const std::list<EdgePoint*> & childrens, const EdgePointCollection& edgeCollection);
-  void setFilteredFieldLines(const std::vector<EdgePoint*> & filteredChildrens, const EdgePointCollection& edgeCollection);
+  void setFieldLines(const std::list<EdgePoint*> & children, const EdgePointCollection& edgeCollection);
+  void setFilteredFieldLines(const std::vector<EdgePoint*> & filteredChildren, const EdgePointCollection& edgeCollection);
 
   std::vector<EdgePoint> _outerEllipsePoints;
   cctag::numerical::geometry::Ellipse _outerEllipse;

--- a/src/cctag/CCTagMarkersBank.cpp
+++ b/src/cctag/CCTagMarkersBank.cpp
@@ -55,9 +55,6 @@ CCTagMarkersBank::CCTagMarkersBank( const std::string & file )
   read( file );
 }
 
-CCTagMarkersBank::~CCTagMarkersBank()
-{
-}
 
 void CCTagMarkersBank::read( const std::string & file )
 {

--- a/src/cctag/CCTagMarkersBank.cpp
+++ b/src/cctag/CCTagMarkersBank.cpp
@@ -19,7 +19,7 @@
 namespace cctag
 {
 
-CCTagMarkersBank::CCTagMarkersBank( const std::size_t nCrowns )
+CCTagMarkersBank::CCTagMarkersBank( std::size_t nCrowns )
 {
   _markers.clear();
   if ( nCrowns == 3 )

--- a/src/cctag/CCTagMarkersBank.cpp
+++ b/src/cctag/CCTagMarkersBank.cpp
@@ -24,26 +24,27 @@ CCTagMarkersBank::CCTagMarkersBank( std::size_t nCrowns )
   _markers.clear();
   if ( nCrowns == 3 )
   {
-    for (int i=0; i<32; ++i)
+    for(const auto & idThreeCrown : CCTagMarkersBank::idThreeCrowns)
     {
       std::vector<float> line;
       line.reserve(5);
-      for (int j=0; j<5; ++j)
+      for(float j : idThreeCrown)
       {
-        line.push_back(CCTagMarkersBank::idThreeCrowns[i][j]);
+        line.push_back(j);
       }
       _markers.push_back(line);
     }
     
-  }else if ( nCrowns == 4 )
+  }
+  else if ( nCrowns == 4 )
   {
-    for (int i=0; i<128; ++i)
+    for(const auto & idFourCrown : CCTagMarkersBank::idFourCrowns)
     {
       std::vector<float> line;
       line.reserve(7);
-      for (int j=0; j<7; ++j)
+      for(float j : idFourCrown)
       {
-        line.push_back(CCTagMarkersBank::idFourCrowns[i][j]);
+        line.push_back(j);
       }
       _markers.push_back(line);
     }

--- a/src/cctag/CCTagMarkersBank.hpp
+++ b/src/cctag/CCTagMarkersBank.hpp
@@ -29,7 +29,7 @@ public:
   CCTagMarkersBank( const std::size_t nCrowns );
   CCTagMarkersBank( const std::string & file );
   
-  virtual ~CCTagMarkersBank();
+  virtual ~CCTagMarkersBank() = default;
 
   void read( const std::string & file );
   std::size_t identify( const std::vector<float> & marker ) const;

--- a/src/cctag/CCTagMarkersBank.hpp
+++ b/src/cctag/CCTagMarkersBank.hpp
@@ -26,8 +26,8 @@ namespace cctag
 class CCTagMarkersBank
 {
 public:
-  CCTagMarkersBank( const std::size_t nCrowns );
-  CCTagMarkersBank( const std::string & file );
+  explicit CCTagMarkersBank( const std::size_t nCrowns );
+  explicit CCTagMarkersBank( const std::string & file );
   
   virtual ~CCTagMarkersBank() = default;
 

--- a/src/cctag/CCTagMarkersBank.hpp
+++ b/src/cctag/CCTagMarkersBank.hpp
@@ -26,7 +26,7 @@ namespace cctag
 class CCTagMarkersBank
 {
 public:
-  explicit CCTagMarkersBank( const std::size_t nCrowns );
+  explicit CCTagMarkersBank( std::size_t nCrowns );
   explicit CCTagMarkersBank( const std::string & file );
   
   virtual ~CCTagMarkersBank() = default;

--- a/src/cctag/Candidate.hpp
+++ b/src/cctag/Candidate.hpp
@@ -22,12 +22,12 @@ public:
     
 	Candidate( EdgePoint* seed, const std::list<EdgePoint*> & convexEdgeSegment,
 		const std::vector<EdgePoint*> & outerEllipsePoints, const cctag::numerical::geometry::Ellipse & outerEllipse,
-		const std::vector<EdgePoint*> & filteredChildrens, int score, std::size_t nLabel )
+		const std::vector<EdgePoint*> & filteredChildren, int score, std::size_t nLabel )
 		: _seed( seed )
 		, _convexEdgeSegment( convexEdgeSegment )
 		, _outerEllipsePoints( outerEllipsePoints )
 	        , _outerEllipse ( outerEllipse )
-		, _filteredChildrens(filteredChildrens)
+		, _filteredChildren(filteredChildren)
 		, _score(score)
 		, _nLabel(nLabel)
 	{}
@@ -38,7 +38,7 @@ public:
 	std::list<EdgePoint*> _convexEdgeSegment;
 	std::vector<EdgePoint*> _outerEllipsePoints;
 	cctag::numerical::geometry::Ellipse _outerEllipse;
-	std::vector<EdgePoint*> _filteredChildrens;
+	std::vector<EdgePoint*> _filteredChildren;
 	int _score;
 	std::size_t _nLabel;
         float _averageReceivedVote;
@@ -46,14 +46,14 @@ public:
         
 #ifdef CCTAG_SERIALIZE
         // From here -- only used for results analysis --
-        std::list<EdgePoint*> _childrens;
+        std::list<EdgePoint*> _children;
         
-        void setChildrens(const std::list<EdgePoint*> & childrens){
-            _childrens = childrens;
+        void setchildren(const std::list<EdgePoint*> & children){
+            _children = children;
         }        
         
-        const std::list<EdgePoint*> & getChildrens(){
-            return _childrens;
+        const std::list<EdgePoint*> & getchildren(){
+            return _children;
         }
         
         // To here -- only used for results analysis --

--- a/src/cctag/Candidate.hpp
+++ b/src/cctag/Candidate.hpp
@@ -32,7 +32,7 @@ public:
 		, _nLabel(nLabel)
 	{}
 
-	virtual ~Candidate() {}
+	virtual ~Candidate() = default;
 
 	EdgePoint* _seed;
 	std::list<EdgePoint*> _convexEdgeSegment;

--- a/src/cctag/DataSerialization.cpp
+++ b/src/cctag/DataSerialization.cpp
@@ -113,8 +113,8 @@ void serializeFlowComponent(boost::archive::text_oarchive & ar, const CCTagFlowC
 
     serializeEllipse(ar, flowComponent._outerEllipse);
 
-    const std::size_t sizeFilteredChildrens = flowComponent._filteredFieldLines.size();
-    ar & BOOST_SERIALIZATION_NVP(sizeFilteredChildrens);
+    const std::size_t sizeFilteredChildren = flowComponent._filteredFieldLines.size();
+    ar & BOOST_SERIALIZATION_NVP(sizeFilteredChildren);
 
     for(const std::vector<EdgePoint> & fL : flowComponent._filteredFieldLines) {
 
@@ -123,8 +123,8 @@ void serializeFlowComponent(boost::archive::text_oarchive & ar, const CCTagFlowC
         }
     }
 
-    const std::size_t sizeChildrens = flowComponent._fieldLines.size();
-    ar & BOOST_SERIALIZATION_NVP(sizeChildrens);
+    const std::size_t sizechildren = flowComponent._fieldLines.size();
+    ar & BOOST_SERIALIZATION_NVP(sizechildren);
 
     for(const std::vector<EdgePoint> & fL : flowComponent._fieldLines) {
 

--- a/src/cctag/DataSerialization.cpp
+++ b/src/cctag/DataSerialization.cpp
@@ -13,7 +13,7 @@ void serializeRadiusRatios(boost::archive::text_oarchive & ar, const std::vector
     const int sizeRadiusRatios = radiusRatios.size();
     ar & BOOST_SERIALIZATION_NVP(sizeRadiusRatios);
 
-    BOOST_FOREACH(const float & ratio, radiusRatios) {
+    for(const float & ratio : radiusRatios) {
         ar & BOOST_SERIALIZATION_NVP(ratio);
     }
 }
@@ -24,7 +24,7 @@ void serializeIdSet(boost::archive::text_oarchive & ar, const IdSet & idSet) {
 
     typedef std::pair< MarkerID, float > IdPair;
 
-    BOOST_FOREACH(const IdPair & idPair, idSet) {
+    for(const IdPair & idPair : idSet) {
         ar & BOOST_SERIALIZATION_NVP(idPair.first);
         ar & BOOST_SERIALIZATION_NVP(idPair.second);
     }
@@ -62,7 +62,7 @@ void serializeVecPoint(boost::archive::text_oarchive & ar, const std::vector< Di
     const int sizePoints = points.size();
     ar & BOOST_SERIALIZATION_NVP(sizePoints);
 
-    BOOST_FOREACH(const DirectedPoint2d<Eigen::Vector3f> & point, points) {
+    for(const DirectedPoint2d<Eigen::Vector3f> & point : points) {
         serializePoint(ar, point);
     }
 }
@@ -71,7 +71,7 @@ void serializePoints(boost::archive::text_oarchive & ar, const std::vector< std:
     const int sizePoints = points.size();
     ar & BOOST_SERIALIZATION_NVP(sizePoints);
 
-    BOOST_FOREACH(const std::vector< DirectedPoint2d<Eigen::Vector3f> > & subPoints, points) {
+    for(const std::vector< DirectedPoint2d<Eigen::Vector3f> > & subPoints : points) {
         serializeVecPoint(ar, subPoints);
     }
 }
@@ -84,7 +84,7 @@ void serializeEllipses(boost::archive::text_oarchive & ar, const std::vector<cct
     const int sizeEllipses = ellipses.size();
     ar & BOOST_SERIALIZATION_NVP(sizeEllipses);
 
-    BOOST_FOREACH(const cctag::numerical::geometry::Ellipse & ellipse, ellipses) {
+    for(const cctag::numerical::geometry::Ellipse & ellipse : ellipses) {
         serializeEllipse(ar, ellipse);
     }
 }
@@ -107,7 +107,7 @@ void serializeFlowComponent(boost::archive::text_oarchive & ar, const CCTagFlowC
     const std::size_t sizeOuterEllipsePoints = outerEllipsePoints.size();
     ar & BOOST_SERIALIZATION_NVP(sizeOuterEllipsePoints);
 
-    BOOST_FOREACH(const EdgePoint & e, outerEllipsePoints) {
+    for(const EdgePoint & e : outerEllipsePoints) {
         serializeEdgePoint(ar, e);
     }
 
@@ -116,9 +116,9 @@ void serializeFlowComponent(boost::archive::text_oarchive & ar, const CCTagFlowC
     const std::size_t sizeFilteredChildrens = flowComponent._filteredFieldLines.size();
     ar & BOOST_SERIALIZATION_NVP(sizeFilteredChildrens);
 
-    BOOST_FOREACH(const std::vector<EdgePoint> & fL, flowComponent._filteredFieldLines) {
+    for(const std::vector<EdgePoint> & fL : flowComponent._filteredFieldLines) {
 
-        BOOST_FOREACH(const EdgePoint & e, fL) {
+        for(const EdgePoint & e : fL) {
             serializeEdgePoint(ar, e);
         }
     }
@@ -126,9 +126,9 @@ void serializeFlowComponent(boost::archive::text_oarchive & ar, const CCTagFlowC
     const std::size_t sizeChildrens = flowComponent._fieldLines.size();
     ar & BOOST_SERIALIZATION_NVP(sizeChildrens);
 
-    BOOST_FOREACH(const std::vector<EdgePoint> & fL, flowComponent._fieldLines) {
+    for(const std::vector<EdgePoint> & fL : flowComponent._fieldLines) {
 
-        BOOST_FOREACH(const EdgePoint & e, fL) {
+        for(const EdgePoint & e : fL) {
             serializeEdgePoint(ar, e);
         }
     }
@@ -137,7 +137,7 @@ void serializeFlowComponent(boost::archive::text_oarchive & ar, const CCTagFlowC
     const std::size_t sizeConvexEdgeSegment = convexEdgeSegment.size();
     ar & BOOST_SERIALIZATION_NVP(sizeConvexEdgeSegment);
 
-    BOOST_FOREACH(const EdgePoint & e, convexEdgeSegment) {
+    for(const EdgePoint & e : convexEdgeSegment) {
         serializeEdgePoint(ar, e);
     }
 
@@ -149,7 +149,7 @@ void serializeFlowComponents(boost::archive::text_oarchive & ar, const std::vect
     const std::size_t sizeFlowComponents = flowComponents.size();
     ar & BOOST_SERIALIZATION_NVP(sizeFlowComponents);
 
-    BOOST_FOREACH(const CCTagFlowComponent & flowComponent, flowComponents) {
+    for(const CCTagFlowComponent & flowComponent : flowComponents) {
         serializeFlowComponent(ar, flowComponent);
     }
 }

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -295,7 +295,6 @@ static void flowComponentAssembling(
 
   int score = -1;
   int iMax = 0;
-  int i = 0;
 
   float ratioExpension = 2.5;
   numerical::geometry::Circle circularResearchArea(
@@ -303,6 +302,7 @@ static void flowComponentAssembling(
          candidate._seed->_flowLength * ratioExpension);
 
   {
+    int i = 0;
     // Search for another segment
     for(const Candidate & anotherCandidate : vCandidateLoopTwo)
     {

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -571,7 +571,7 @@ void cctagDetectionFromEdges(
         EdgePointCollection& edgeCollection,
         const cv::Mat&          src,
         const std::vector<EdgePoint*>& seeds,
-        const std::size_t frame,
+        std::size_t frame,
         int pyramidLevel,
         float scale,
         const Parameters & providedParams,
@@ -770,11 +770,11 @@ cctag::TagPipe* initCuda( int      pipeId,
 void cctagDetection(
         CCTag::List& markers,
         int          pipeId,
-        const std::size_t frame, 
+        std::size_t frame,
         const cv::Mat & imgGraySrc,
         const Parameters & providedParams,
         const cctag::CCTagMarkersBank & bank,
-        const bool bDisplayEllipses,
+        bool bDisplayEllipses,
         cctag::logtime::Mgmt* durations )
 
 {

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -124,32 +124,32 @@ static void completeFlowComponent(
   
   try
   {
-    std::list<EdgePoint*> childrens;
+    std::list<EdgePoint*> children;
 
-    childrensOf(edgeCollection, candidate._convexEdgeSegment, childrens);
+    childrenOf(edgeCollection, candidate._convexEdgeSegment, children);
 
-    if (childrens.size() < params._minPointsSegmentCandidate)
+    if (children.size() < params._minPointsSegmentCandidate)
     {
       return;
     }
 
-    candidate._score = childrens.size();
+    candidate._score = children.size();
 
     float SmFinal = 1e+10;
 
-    std::vector<EdgePoint*> & filteredChildrens = candidate._filteredChildrens;
+    std::vector<EdgePoint*> & filteredChildren = candidate._filteredChildren;
 
     outlierRemoval(
-            childrens, 
-            filteredChildrens,
+            children,
+            filteredChildren,
             SmFinal, 
             params._threshRobustEstimationOfOuterEllipse,
             kWeight,
             60);
 
-    if (filteredChildrens.size() < 5)
+    if (filteredChildren.size() < 5)
     {
-      DO_TALK( CCTAG_COUT_DEBUG(" filteredChildrens.size() < 5 "); )
+      DO_TALK( CCTAG_COUT_DEBUG(" filteredChildren.size() < 5 "); )
       return;
     }
 
@@ -158,7 +158,7 @@ static void completeFlowComponent(
     {
       ssize_t nSegmentCommon = -1;
 
-      for(EdgePoint * p : filteredChildrens)
+      for(EdgePoint * p : filteredChildren)
       {
         if (p->_nSegmentOut != -1)
         {
@@ -181,7 +181,7 @@ static void completeFlowComponent(
         nLabel = nSegmentCommon;
       }
 
-      for(EdgePoint * p : filteredChildrens)
+      for(EdgePoint * p : filteredChildren)
       {
         p->_nSegmentOut = nLabel;
       }
@@ -192,9 +192,9 @@ static void completeFlowComponent(
 
     bool goodInit = false;
 
-    goodInit = ellipseGrowingInit(filteredChildrens, outerEllipse);
+    goodInit = ellipseGrowingInit(filteredChildren, outerEllipse);
 
-    ellipseGrowing2(edgeCollection, filteredChildrens, outerEllipsePoints, outerEllipse,
+    ellipseGrowing2(edgeCollection, filteredChildren, outerEllipsePoints, outerEllipse,
                     params._ellipseGrowingEllipticHullWidth, runId, goodInit);
 
     candidate._nLabel = nLabel;
@@ -244,11 +244,11 @@ static void completeFlowComponent(
     }
 
 #ifdef CCTAG_SERIALIZE
-    // Add childrens to output the filtering results (from outlierRemoval)
-    vCandidateLoopTwo.back().setChildrens(childrens);
+    // Add children to output the filtering results (from outlierRemoval)
+    vCandidateLoopTwo.back().setchildren(children);
 
     // Write all selectedFlowComponent
-    CCTagFlowComponent flowComponent(edgeCollection, outerEllipsePoints, childrens, filteredChildrens,
+    CCTagFlowComponent flowComponent(edgeCollection, outerEllipsePoints, children, filteredChildren,
                                      outerEllipse, candidate._convexEdgeSegment,
                                     *(candidate._seed), params._nCircles);
     CCTagFileDebug::instance().outputFlowComponentInfos(flowComponent);
@@ -357,7 +357,7 @@ static void flowComponentAssembling(
     DO_TALK( CCTAG_COUT_VAR_DEBUG(selectedCandidate._outerEllipse); )
 
     if( isAnotherSegment(edgeCollection, outerEllipse, outerEllipsePoints, 
-            selectedCandidate._filteredChildrens, selectedCandidate,
+            selectedCandidate._filteredChildren, selectedCandidate,
             cctagPoints, params._nCrowns * 2,
             params._thrMedianDistanceEllipse) )
     {
@@ -425,7 +425,7 @@ static void cctagDetectionFromEdgesLoopTwoIteration(
       }
 
       // Add the flowComponent from candidate to cctagPoints
-      if (! addCandidateFlowtoCCTag(edgeCollection, candidate._filteredChildrens, 
+      if (! addCandidateFlowtoCCTag(edgeCollection, candidate._filteredChildren,
               candidate._outerEllipsePoints, outerEllipse,
               cctagPoints, params._nCrowns * 2))
       {

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -798,7 +798,7 @@ void cctagDetection(
                                params._numberOfProcessedMultiresLayers,
                                cuda_allocates );
 
-    cctag::TagPipe* pipe1 = 0;
+    cctag::TagPipe* pipe1 = nullptr;
 #ifdef WITH_CUDA
     if( params._useCuda ) {
         pipe1 = initCuda( pipeId,

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -158,7 +158,7 @@ static void completeFlowComponent(
     {
       ssize_t nSegmentCommon = -1;
 
-      BOOST_FOREACH(EdgePoint * p, filteredChildrens)
+      for(EdgePoint * p : filteredChildrens)
       {
         if (p->_nSegmentOut != -1)
         {
@@ -181,7 +181,7 @@ static void completeFlowComponent(
         nLabel = nSegmentCommon;
       }
 
-      BOOST_FOREACH(EdgePoint * p, filteredChildrens)
+      for(EdgePoint * p : filteredChildrens)
       {
         p->_nSegmentOut = nLabel;
       }
@@ -205,7 +205,7 @@ static void completeFlowComponent(
 
     float distMax = 0;
 
-    BOOST_FOREACH(EdgePoint * p, outerEllipsePoints)
+    for(EdgePoint * p : outerEllipsePoints)
     {
       float distFinal = numerical::distancePointEllipse(*p, outerEllipse);
       vDistFinal.push_back(distFinal);
@@ -304,7 +304,7 @@ static void flowComponentAssembling(
 
   {
     // Search for another segment
-    BOOST_FOREACH(const Candidate & anotherCandidate, vCandidateLoopTwo)
+    for(const Candidate & anotherCandidate : vCandidateLoopTwo)
     {
       if (&candidate != &anotherCandidate)
       {
@@ -482,7 +482,7 @@ static void cctagDetectionFromEdgesLoopTwoIteration(
       float distMax = 0;
 
       // TODO@stian: TBB parallel reduction
-      BOOST_FOREACH(EdgePoint * p, outerEllipsePoints)
+      for(EdgePoint * p : outerEllipsePoints)
       {
         float distFinal = numerical::distancePointEllipse(*p, outerEllipse);
         resSquare += distFinal; //*distFinal;
@@ -501,7 +501,7 @@ static void cctagDetectionFromEdgesLoopTwoIteration(
 
       bool isValid = true;
 
-      BOOST_FOREACH(const EdgePoint * p, outerEllipsePoints)
+      for(const EdgePoint * p : outerEllipsePoints)
       {
         if (!isInHull(qIn, qOut, p))
         {
@@ -523,7 +523,7 @@ static void cctagDetectionFromEdgesLoopTwoIteration(
       float quality2 = 0;
 
       // todo@Lilian: no longer used ?
-      BOOST_FOREACH(const EdgePoint* p, outerEllipsePoints)
+      for(const EdgePoint* p : outerEllipsePoints)
       {
         quality2 += p->normGradient();
       }
@@ -658,7 +658,7 @@ void cctagDetectionFromEdges(
   DO_TALK(
     CCTAG_COUT_VAR_DEBUG(vCandidateLoopTwo.size());
     CCTAG_COUT_DEBUG("================= List of seeds =================");
-    BOOST_FOREACH(const Candidate & anotherCandidate, vCandidateLoopTwo)
+    for(const Candidate & anotherCandidate : vCandidateLoopTwo)
     {
       CCTAG_COUT_DEBUG("X = [ " << anotherCandidate._seed->x() << " , " << anotherCandidate._seed->y() << "]");
     }
@@ -994,7 +994,7 @@ void cctagDetection(
     CCTagVisualDebug::instance().writeIdentificationView(markers);
     CCTagFileDebug::instance().newSession("identification.txt");
 
-    BOOST_FOREACH(const CCTag & marker, markers)
+    for(const CCTag & marker : markers)
     {
         CCTagFileDebug::instance().outputMarkerInfos(marker);
     }

--- a/src/cctag/Detection.hpp
+++ b/src/cctag/Detection.hpp
@@ -40,8 +40,8 @@ void cctagDetection(
         CCTag::List& markers,
         int          pipeId,
         std::size_t frame,
-        const cv::Mat & graySrc,
-        const Parameters & params,
+        const cv::Mat & imgGraySrc,
+        const Parameters & providedParams,
         const cctag::CCTagMarkersBank & bank,
         bool bDisplayEllipses = true,
         logtime::Mgmt* durations = nullptr );
@@ -54,7 +54,7 @@ void cctagDetectionFromEdges(
         std::size_t       frame,
         int pyramidLevel,
         float scale,
-        const Parameters & params,
+        const Parameters & providedParams,
         logtime::Mgmt* durations );
 
 void createImageForVoteResultDebug(

--- a/src/cctag/Detection.hpp
+++ b/src/cctag/Detection.hpp
@@ -44,7 +44,7 @@ void cctagDetection(
         const Parameters & params,
         const cctag::CCTagMarkersBank & bank,
         const bool bDisplayEllipses = true,
-        logtime::Mgmt* durations = 0 );
+        logtime::Mgmt* durations = nullptr );
 
 void cctagDetectionFromEdges(
         CCTag::List&            markers,

--- a/src/cctag/Detection.hpp
+++ b/src/cctag/Detection.hpp
@@ -39,11 +39,11 @@ class EdgePointImage;
 void cctagDetection(
         CCTag::List& markers,
         int          pipeId,
-        const std::size_t frame,
+        std::size_t frame,
         const cv::Mat & graySrc,
         const Parameters & params,
         const cctag::CCTagMarkersBank & bank,
-        const bool bDisplayEllipses = true,
+        bool bDisplayEllipses = true,
         logtime::Mgmt* durations = nullptr );
 
 void cctagDetectionFromEdges(
@@ -51,7 +51,7 @@ void cctagDetectionFromEdges(
         EdgePointCollection& edgeCollection,
         const cv::Mat&          src,
         const std::vector<EdgePoint*>& seeds,
-        const std::size_t       frame,
+        std::size_t       frame,
         int pyramidLevel,
         float scale,
         const Parameters & params,

--- a/src/cctag/EllipseGrowing.cpp
+++ b/src/cctag/EllipseGrowing.cpp
@@ -54,7 +54,7 @@ bool initMarkerCenter(cctag::Point2d<Eigen::Vector3f> & markerCenter,
       {
         numerical::ellipseFitting(innerEllipse, markerPoints[0]);
 
-        for(Point2d<Eigen::Vector3f> pt : markerPoints[0])
+        for(const Point2d<Eigen::Vector3f>& pt : markerPoints[0])
         {
           CCTagVisualDebug::instance().drawPoint(pt, cctag::color_red);
         }

--- a/src/cctag/EllipseGrowing.cpp
+++ b/src/cctag/EllipseGrowing.cpp
@@ -54,7 +54,7 @@ bool initMarkerCenter(cctag::Point2d<Eigen::Vector3f> & markerCenter,
       {
         numerical::ellipseFitting(innerEllipse, markerPoints[0]);
 
-        BOOST_FOREACH(Point2d<Eigen::Vector3f> pt, markerPoints[0])
+        for(Point2d<Eigen::Vector3f> pt : markerPoints[0])
         {
           CCTagVisualDebug::instance().drawPoint(pt, cctag::color_red);
         }
@@ -92,7 +92,7 @@ bool addCandidateFlowtoCCTag(EdgePointCollection& edgeCollection,
   std::vector< std::vector< DirectedPoint2d<Eigen::Vector3f> > >::reverse_iterator itp = cctagPoints.rbegin();
   itp->reserve(outerEllipsePoints.size());
 
-  BOOST_FOREACH(EdgePoint * e, outerEllipsePoints)
+  for(EdgePoint * e : outerEllipsePoints)
   {
     itp->push_back(DirectedPoint2d<Eigen::Vector3f>(e->x(), e->y(), e->dX(), e->dY()));
   }
@@ -267,7 +267,7 @@ numerical::geometry::Circle computeCircleFromOuterEllipsePoints(const std::vecto
 
   float dist;
 
-  BOOST_FOREACH(const EdgePoint * const e, filteredChildrens)
+  for(const EdgePoint * const e : filteredChildrens)
   {
     dist = std::min(
             cctag::numerical::distancePoints2D((Point2d<Vector3s>)(*e), p1),
@@ -415,7 +415,7 @@ void ellipseGrowing2(
   const size_t threadMask = (size_t)1 << runId;
   outerEllipsePoints.reserve(filteredChildrens.size()*3);
 
-  BOOST_FOREACH(EdgePoint * children, filteredChildrens)
+  for(EdgePoint * children : filteredChildrens)
   {
     outerEllipsePoints.push_back(children);
     children->_processed |= threadMask;
@@ -441,7 +441,7 @@ void ellipseGrowing2(
       numerical::geometry::Ellipse qIn, qOut;
       computeHull(ellipse, ellipseGrowingEllipticHullWidth, qIn, qOut);
       lastSizePoints = 0;
-      BOOST_FOREACH(const EdgePoint * point, outerEllipsePoints)
+      for(const EdgePoint * point : outerEllipsePoints)
       {
         if (isInHull(qIn, qOut, point))
         {
@@ -459,7 +459,7 @@ void ellipseGrowing2(
 
       computeHull(ellipse, ellipseGrowingEllipticHullWidth, qIn, qOut);
       newSizePoints = 0;
-      BOOST_FOREACH(const EdgePoint * point, outerEllipsePoints)
+      for(const EdgePoint * point : outerEllipsePoints)
       {
         if (isInHull(qIn, qOut, point))
         {

--- a/src/cctag/EllipseGrowing.cpp
+++ b/src/cctag/EllipseGrowing.cpp
@@ -265,11 +265,10 @@ numerical::geometry::Circle computeCircleFromOuterEllipsePoints(const std::vecto
                     cctag::numerical::distancePoints2D((Point2d<Vector3s>)(*pMax), p1),
                     cctag::numerical::distancePoints2D((Point2d<Vector3s>)(*pMax), p2));
 
-  float dist;
 
   for(const EdgePoint * const e : filteredChildrens)
   {
-    dist = std::min(
+    const float dist = std::min(
             cctag::numerical::distancePoints2D((Point2d<Vector3s>)(*e), p1),
             cctag::numerical::distancePoints2D((Point2d<Vector3s>)(*e), p2));
 

--- a/src/cctag/EllipseGrowing.cpp
+++ b/src/cctag/EllipseGrowing.cpp
@@ -327,7 +327,7 @@ bool ellipseGrowingInit(const std::vector<EdgePoint*>& filteredChildrens, numeri
   return goodInit;
 }
 
-void connectedPoint(std::vector<EdgePoint*>& pts, const int runId, 
+void connectedPoint(std::vector<EdgePoint*>& pts, int runId,
         const EdgePointCollection& img, numerical::geometry::Ellipse& qIn,
         numerical::geometry::Ellipse& qOut, int x, int y)
 {
@@ -389,7 +389,8 @@ void computeHull(const numerical::geometry::Ellipse& ellipse, float delta,
 void ellipseHull(const EdgePointCollection& img,
         std::vector<EdgePoint*>& pts,
         numerical::geometry::Ellipse& ellipse,
-        float delta, const std::size_t runId)
+        float delta,
+        std::size_t runId)
 {
   numerical::geometry::Ellipse qIn, qOut;
   computeHull(ellipse, delta, qIn, qOut);
@@ -408,7 +409,7 @@ void ellipseGrowing2(
         const std::vector<EdgePoint*>& filteredChildrens, 
         std::vector<EdgePoint*>& outerEllipsePoints,
         numerical::geometry::Ellipse& ellipse,
-        const float ellipseGrowingEllipticHullWidth,
+        float ellipseGrowingEllipticHullWidth,
         std::size_t runId,
         bool goodInit)
 {

--- a/src/cctag/EllipseGrowing.hpp
+++ b/src/cctag/EllipseGrowing.hpp
@@ -104,7 +104,7 @@ inline bool isOnTheSameSide(const Point2d<Eigen::Vector3f> & p1, const Point2d<E
  * @param abscissa of the point
  * @param ordinate of the point
  */
-void connectedPoint( std::vector<EdgePoint*>& pts, const int runId, const EdgePointCollection& img, cctag::numerical::geometry::Ellipse& qIn, cctag::numerical::geometry::Ellipse& qOut, int x, int y );
+void connectedPoint( std::vector<EdgePoint*>& pts, int runId, const EdgePointCollection& img, cctag::numerical::geometry::Ellipse& qIn, cctag::numerical::geometry::Ellipse& qOut, int x, int y );
 
 /** @brief Compute the hull from ellipse
  * @param ellipse ellipse from which the hull is computed
@@ -117,7 +117,7 @@ void computeHull( const cctag::numerical::geometry::Ellipse& ellipse, float delt
  * which fits pt. New points will be added in pts
  * @param ellipse ellipse is an optionnal parameter if the user decide to choose his hull from an ellipse
  */
-void ellipseHull( const EdgePointCollection& img, std::vector<EdgePoint*>& pts, cctag::numerical::geometry::Ellipse& ellipse, float delta, const std::size_t runId);
+void ellipseHull( const EdgePointCollection& img, std::vector<EdgePoint*>& pts, cctag::numerical::geometry::Ellipse& ellipse, float delta, std::size_t runId);
 
 /** @brief Ellipse growing
  * @param childrens vote winner children points
@@ -128,7 +128,7 @@ void ellipseHull( const EdgePointCollection& img, std::vector<EdgePoint*>& pts, 
 
 void ellipseGrowing2( const EdgePointCollection& img, const std::vector<EdgePoint*>& filteredChildrens,
                       std::vector<EdgePoint*>& outerEllipsePoints, numerical::geometry::Ellipse& ellipse,
-                      const float ellipseGrowingEllipticHullWidth, std::size_t nLabel, bool goodInit);
+                      float ellipseGrowingEllipticHullWidth, std::size_t nLabel, bool goodInit);
 
 } // namespace cctag
 

--- a/src/cctag/EllipseGrowing.hpp
+++ b/src/cctag/EllipseGrowing.hpp
@@ -55,14 +55,14 @@ bool initMarkerCenter(
 
 bool addCandidateFlowtoCCTag(
         EdgePointCollection& edgeCollection,
-        const std::vector< EdgePoint* > & filteredChildrens,
+        const std::vector< EdgePoint* > & filteredChildren,
         const std::vector< EdgePoint* > & outerEllipsePoints,
         const cctag::numerical::geometry::Ellipse& outerEllipse,
         std::vector< std::vector< DirectedPoint2d<Eigen::Vector3f> > >& cctagPoints,
         std::size_t numCircles);
 
 bool ellipseGrowingInit(
-        const std::vector<EdgePoint*>& filteredChildrens,
+        const std::vector<EdgePoint*>& filteredChildren,
         cctag::numerical::geometry::Ellipse& ellipse);
 
 /** @brief Is a point in an elliptical hull ?
@@ -120,13 +120,13 @@ void computeHull( const cctag::numerical::geometry::Ellipse& ellipse, float delt
 void ellipseHull( const EdgePointCollection& img, std::vector<EdgePoint*>& pts, cctag::numerical::geometry::Ellipse& ellipse, float delta, std::size_t runId);
 
 /** @brief Ellipse growing
- * @param childrens vote winner children points
+ * @param children vote winner children points
  * @param outerEllipsePoints outer ellipse points
  * @param ellipse target ellipse
  * @param Width of elliptic hull in ellipse growing
  */
 
-void ellipseGrowing2( const EdgePointCollection& img, const std::vector<EdgePoint*>& filteredChildrens,
+void ellipseGrowing2( const EdgePointCollection& img, const std::vector<EdgePoint*>& filteredChildren,
                       std::vector<EdgePoint*>& outerEllipsePoints, numerical::geometry::Ellipse& ellipse,
                       float ellipseGrowingEllipticHullWidth, std::size_t runId, bool goodInit);
 

--- a/src/cctag/EllipseGrowing.hpp
+++ b/src/cctag/EllipseGrowing.hpp
@@ -128,7 +128,7 @@ void ellipseHull( const EdgePointCollection& img, std::vector<EdgePoint*>& pts, 
 
 void ellipseGrowing2( const EdgePointCollection& img, const std::vector<EdgePoint*>& filteredChildrens,
                       std::vector<EdgePoint*>& outerEllipsePoints, numerical::geometry::Ellipse& ellipse,
-                      float ellipseGrowingEllipticHullWidth, std::size_t nLabel, bool goodInit);
+                      float ellipseGrowingEllipticHullWidth, std::size_t runId, bool goodInit);
 
 } // namespace cctag
 

--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -198,8 +198,8 @@ float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildrens, floa
             using namespace boost::numeric;
             //using namespace cctag::numerical;
 
-            EdgePoint* pAngle1 = NULL;
-            EdgePoint* pAngle2 = NULL;
+            EdgePoint* pAngle1 = nullptr;
+            EdgePoint* pAngle2 = nullptr;
 
             float min = 1.1;
 

--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -22,9 +22,9 @@
 #include <cctag/geometry/Point.hpp>
 #include <cctag/Fitting.hpp>
 #include <cmath>
-#include <float.h>
+#include <cfloat>
 #include <fstream>
-#include <math.h>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <vector>

--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -194,7 +194,7 @@ template void fitEllipse(std::vector<cctag::Point2d<Eigen::Vector3f>>::const_ite
 
 } // geometry
 
-float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildrens, float thrCosDiffMax, Point2d<Vector3s> & p1, Point2d<Vector3s> & p2) {
+float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildren, float thrCosDiffMax, Point2d<Vector3s> & p1, Point2d<Vector3s> & p2) {
             using namespace boost::numeric;
             //using namespace cctag::numerical;
 
@@ -207,9 +207,9 @@ float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildrens, floa
 
             float distMax = 0.f;
 
-            EdgePoint* p0 = filteredChildrens.front();
+            EdgePoint* p0 = filteredChildren.front();
 
-            if (filteredChildrens.size()) {
+            if (filteredChildren.size()) {
 
                 normGrad = std::sqrt(p0->dX() * p0->dX() + p0->dY() * p0->dY());
 
@@ -217,9 +217,9 @@ float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildrens, floa
                 float gx0 = p0->dX() / normGrad;
                 float gy0 = p0->dY() / normGrad;
 
-                std::vector<cctag::EdgePoint*>::const_iterator it = ++filteredChildrens.begin();
+                std::vector<cctag::EdgePoint*>::const_iterator it = ++filteredChildren.begin();
 
-                for (; it != filteredChildrens.end(); ++it) {
+                for (; it != filteredChildren.end(); ++it) {
                     EdgePoint* pCurrent = *it;
 
                     normGrad = std::sqrt(pCurrent->dX() * pCurrent->dX() + pCurrent->dY() * pCurrent->dY());
@@ -252,11 +252,11 @@ float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildrens, floa
                 min = 1.f;
                 distMax = 0.f;
 
-                it = filteredChildrens.begin();
+                it = filteredChildren.begin();
 
                 //CCTAG_COUT(" 2- 2eme element" << **it);
 
-                for (; it != filteredChildrens.end(); ++it) {
+                for (; it != filteredChildren.end(); ++it) {
                     EdgePoint* pCurrent = *it;
 
                     normGrad = std::sqrt(pCurrent->dX() * pCurrent->dX() + pCurrent->dY() * pCurrent->dY());

--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -203,15 +203,14 @@ float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildren, float
 
             float min = 1.1;
 
-            float normGrad = -1;
-
             float distMax = 0.f;
 
             EdgePoint* p0 = filteredChildren.front();
 
-            if (filteredChildren.size()) {
+            if (!filteredChildren.empty())
+            {
 
-                normGrad = std::sqrt(p0->dX() * p0->dX() + p0->dY() * p0->dY());
+                float normGrad = std::sqrt(p0->dX() * p0->dX() + p0->dY() * p0->dY());
 
                 // Step 1
                 float gx0 = p0->dX() / normGrad;

--- a/src/cctag/Fitting.hpp
+++ b/src/cctag/Fitting.hpp
@@ -20,13 +20,13 @@
 namespace cctag {
 namespace numerical {
 
-float innerProdMin( const std::vector<cctag::EdgePoint*>& childrens, float thrCosDiffMax, Point2d<Vector3s> & p1, Point2d<Vector3s> & p2 );
+float innerProdMin( const std::vector<cctag::EdgePoint*>& filteredChildren, float thrCosDiffMax, Point2d<Vector3s> & p1, Point2d<Vector3s> & p2 );
 
 void circleFitting(cctag::numerical::geometry::Ellipse& e, const std::vector<cctag::EdgePoint*>& points);
 
-void ellipseFitting( cctag::numerical::geometry::Ellipse& e, const std::vector< Point2d<Eigen::Vector3f> >& childrens );
+void ellipseFitting( cctag::numerical::geometry::Ellipse& e, const std::vector< Point2d<Eigen::Vector3f> >& points );
 
-void ellipseFitting( cctag::numerical::geometry::Ellipse& e, const std::vector<cctag::EdgePoint*>& childrens );
+void ellipseFitting( cctag::numerical::geometry::Ellipse& e, const std::vector<cctag::EdgePoint*>& points );
 
 } // namespace numerical
 } // namespace cctag

--- a/src/cctag/ICCTag.cpp
+++ b/src/cctag/ICCTag.cpp
@@ -35,9 +35,9 @@ namespace cctag {
 void cctagDetection(
       boost::ptr_list<ICCTag> & markers,
       int                       pipeId,
-      const std::size_t frame,
+      std::size_t frame,
       const cv::Mat & graySrc,
-      const std::size_t nRings,
+      std::size_t nRings,
       logtime::Mgmt* durations,
       const std::string & parameterFilename,
       const std::string & cctagBankFilename)
@@ -71,7 +71,7 @@ void cctagDetection(
 void cctagDetection(
       boost::ptr_list<ICCTag> & markers,
       int                       pipeId,
-      const std::size_t frame,
+      std::size_t frame,
       const cv::Mat & graySrc,
       const cctag::Parameters & params,
       logtime::Mgmt* durations,

--- a/src/cctag/ICCTag.cpp
+++ b/src/cctag/ICCTag.cpp
@@ -79,7 +79,7 @@ void cctagDetection(
 {
   boost::ptr_list<cctag::CCTag> cctags;
   
-  if ( pBank == NULL)
+  if ( pBank == nullptr)
   {
     CCTagMarkersBank bank(params._nCrowns);
     cctag::cctagDetection(cctags, pipeId, frame, graySrc, params, bank, false, durations);

--- a/src/cctag/ICCTag.cpp
+++ b/src/cctag/ICCTag.cpp
@@ -89,7 +89,7 @@ void cctagDetection(
   }
   
   markers.clear();
-  BOOST_FOREACH(const cctag::CCTag & cctag, cctags)
+  for(const cctag::CCTag & cctag : cctags)
   {
     markers.push_back(new cctag::CCTag(cctag));
   }

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -21,7 +21,7 @@ namespace logtime {
 struct Mgmt;
 }
   
-typedef int MarkerID;
+using MarkerID = int;
 
 class ICCTag
 {

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -27,26 +27,26 @@ class ICCTag
 {
 public:
 
-	ICCTag()
-		: _x( 0.f )
-		, _y( 0.f )
-		, _id( -1 )
-	{ }
+    ICCTag()
+        : _x( 0.f )
+        , _y( 0.f )
+        , _id( -1 )
+    { }
                 
-        virtual float x() const = 0;
-        virtual float y() const = 0;
-        virtual MarkerID id() const = 0;
-        virtual int getStatus() const = 0;
+	virtual float x() const = 0;
+	virtual float y() const = 0;
+	virtual MarkerID id() const = 0;
+	virtual int getStatus() const = 0;
 
-	virtual ~ICCTag() = default;
+    virtual ~ICCTag() = default;
 
-	virtual ICCTag* clone() const = 0;
+    virtual ICCTag* clone() const = 0;
 
 
 protected:
-	float _x;
-	float _y;
-	MarkerID _id;
+    float _x;
+    float _y;
+    MarkerID _id;
         int _status; // WARNING: only markers with status == 1 are the valid ones. (status available via getStatus()) 
                      // A marker correctly detected and identified has a status 1.
                      // Otherwise, it can be detected but not correctly identified.
@@ -54,7 +54,7 @@ protected:
 
 inline ICCTag* new_clone(const ICCTag& a)
 {
-	return a.clone();
+    return a.clone();
 }
 
 /**

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -73,8 +73,8 @@ void cctagDetection(
       int                       pipeId,
       std::size_t frame,
       const cv::Mat & graySrc,
-      logtime::Mgmt* durations = nullptr,
       std::size_t nRings = 3,
+      logtime::Mgmt* durations = nullptr,
       const std::string & parameterFile = "",
       const std::string & cctagBankFilename = "");
 

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -71,17 +71,17 @@ inline ICCTag* new_clone(const ICCTag& a)
 void cctagDetection(
       boost::ptr_list<ICCTag> & markers,
       int                       pipeId,
-      const std::size_t frame,
+      std::size_t frame,
       const cv::Mat & graySrc,
       logtime::Mgmt* durations = nullptr,
-      const std::size_t nRings = 3,
+      std::size_t nRings = 3,
       const std::string & parameterFile = "",
       const std::string & cctagBankFilename = "");
 
 void cctagDetection(
       boost::ptr_list<ICCTag> & markers,
       int                       pipeId,
-      const std::size_t frame,
+      std::size_t frame,
       const cv::Mat & graySrc,
       const cctag::Parameters & params,
       logtime::Mgmt* durations = nullptr,

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -73,7 +73,7 @@ void cctagDetection(
       int                       pipeId,
       const std::size_t frame,
       const cv::Mat & graySrc,
-      logtime::Mgmt* durations = 0,
+      logtime::Mgmt* durations = nullptr,
       const std::size_t nRings = 3,
       const std::string & parameterFile = "",
       const std::string & cctagBankFilename = "");
@@ -84,8 +84,8 @@ void cctagDetection(
       const std::size_t frame,
       const cv::Mat & graySrc,
       const cctag::Parameters & params,
-      logtime::Mgmt* durations = 0,
-      const CCTagMarkersBank * bank = NULL);
+      logtime::Mgmt* durations = nullptr,
+      const CCTagMarkersBank * bank = nullptr);
 
 }
 

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -38,7 +38,7 @@ public:
         virtual MarkerID id() const = 0;
         virtual int getStatus() const = 0;
 
-	virtual ~ICCTag() {}
+	virtual ~ICCTag() = default;
 
 	virtual ICCTag* clone() const = 0;
 

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -85,7 +85,7 @@ void cctagDetection(
       const cv::Mat & graySrc,
       const cctag::Parameters & params,
       logtime::Mgmt* durations = nullptr,
-      const CCTagMarkersBank * bank = nullptr);
+      const CCTagMarkersBank * pBank = nullptr);
 
 }
 

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -102,17 +102,17 @@ bool orazioDistanceRobust(
       accumulator_set< float, features< tag::mean > > accSup;
       
       bool doAccumulate = false;
-      for( std::size_t i = 0 ; i < imgSig.size(); ++i )
+      for(float i : imgSig)
       {
-        if ( (!doAccumulate) && ( imgSig[i] < medianSig ) )
+        if ( (!doAccumulate) && ( i < medianSig ) )
           doAccumulate = true;
           
         if (doAccumulate)
         {
-          if ( imgSig[i] < medianSig )
-            accInf( imgSig[i] );
+          if ( i < medianSig )
+            accInf( i );
           else
-            accSup( imgSig[i] );
+            accSup( i );
         }
       }
       const float muw = boost::accumulators::mean( accSup );
@@ -134,18 +134,18 @@ bool orazioDistanceRobust(
         // Compute the idc-th profile from the radius ratio
         // todo@Lilian: to be pre-computed
         float x = cut.beginSig();
-        for( std::size_t i = 0; i < digit.size(); ++i )
+        for(float & i : digit)
         {
           std::ssize_t ldum = 0;
-          for( std::size_t j = 0; j < rrBank[idc].size(); ++j )
+          for(float j : rrBank[idc])
           {
-            if( 1.f / rrBank[idc][j] <= x )
+            if( 1.f / j <= x )
             {
               ++ldum;
             }
           }
           // set odd value to -1 and even value to 1
-          digit[i] = - ( ldum % 2 ) * 2 + 1;
+          i = - ( ldum % 2 ) * 2 + 1;
           
           x += stepX;
         }

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -1345,7 +1345,7 @@ int identify_step_2(
 #ifdef WITH_CUDA
                         cctag.getNearbyPointBuffer(),
 #else
-                        0,
+                        nullptr,
 #endif
                         residual
                         );

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -1405,7 +1405,7 @@ int identify_step_2(
       int i = 0;
       int iMax = 0;
 
-      BOOST_FOREACH(const std::list<float> & lResult, vScore)
+      for(const std::list<float> & lResult : vScore)
       {
         if (lResult.size() > maxSize)
         {
@@ -1420,7 +1420,7 @@ int identify_step_2(
       assert( vScore.size() > 0 );
       assert( vScore.size() > iMax );
 #endif // GRIFF_DEBUG
-      BOOST_FOREACH(const float & proba, vScore[iMax])
+      for(const float & proba : vScore[iMax])
       {
         score += proba;
       }

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -480,7 +480,7 @@ void collectCuts(
     // Here only beginSig is set based on the input argument beginSig while endSig is set to 1.f as 
     // any type of cctags encodes, by construction, a 1D bar-code until the outer ellipse (image 
     // of the unit circle).
-    cuts.push_back( cctag::ImageCut(center, outerPoint, beginSig, 1.f, nSamplesInCut) );
+    cuts.emplace_back(center, outerPoint, beginSig, 1.f, nSamplesInCut );
     cctag::ImageCut & cut = cuts.back();
     cutInterpolated( cut, src);
     // Remove the cut from the vector if out of the image bounds.
@@ -1441,7 +1441,7 @@ int identify_step_2(
         for(const float radiusRatio : cctag.radiusRatios())
         {
           cctag::numerical::geometry::Circle circle(1.f / radiusRatio);
-          ellipses.push_back(cctag::numerical::geometry::Ellipse(mInvH.transpose()*circle.matrix()*mInvH));
+          ellipses.emplace_back(mInvH.transpose()*circle.matrix()*mInvH);
         }
 
         // Push the outer ellipse

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -49,7 +49,7 @@ bool orazioDistanceRobust(
         std::vector<std::list<float> > & vScore,
         const RadiusRatioBank & rrBank,
         const std::vector<cctag::ImageCut> & cuts,
-        const float minIdentProba)
+        float minIdentProba)
 {
   BOOST_ASSERT( cuts.size() > 0 );
 
@@ -277,7 +277,7 @@ void extractSignalUsingHomography(
   //blurImageCut(sigma, cut);
 }
 
-void blurImageCut(const float sigma, std::vector<float> & signal)
+void blurImageCut(float sigma, std::vector<float> & signal)
 {
   //const std::vector<float> kernel = { 0.0044, 0.0540, 0.2420, 0.3991, 0.2420, 0.0540, 0.0044 };
   const std::vector<float> kernel = { 0.0276, 0.0663, 0.1238, 0.1802, 0.2042, 0.1802, 0.1238, 0.0663, 0.0276 };
@@ -327,8 +327,8 @@ void extractSignalUsingHomographyDeprec(
         const cv::Mat & src,
         Eigen::Matrix3f & mHomography,
         std::size_t nSamples,
-        const float begin,
-        const float end)
+        float begin,
+        float end)
 {
   using namespace boost;
   using namespace cctag::numerical;
@@ -470,8 +470,8 @@ void collectCuts(
         const cv::Mat & src,
         const cctag::Point2d<Eigen::Vector3f> & center,
         const std::vector< cctag::DirectedPoint2d<Eigen::Vector3f> > & outerPoints,
-        const std::size_t nSamplesInCut,
-        const float beginSig )
+        std::size_t nSamplesInCut,
+        float beginSig )
 {
   // Collect all the 1D image signals from center to the outer points.
   cuts.reserve( outerPoints.size() );
@@ -598,7 +598,7 @@ void selectCutCheapUniform( std::vector< cctag::ImageCut > & vSelectedCuts,
 }
 
 /* Ugly -> perform an iterative optimization*/
-bool outerEdgeRefinement(ImageCut & cut, const cv::Mat & src, const float scale, const size_t numSamplesOuterEdgePointsRefinement)
+bool outerEdgeRefinement(ImageCut & cut, const cv::Mat & src, float scale, std::size_t numSamplesOuterEdgePointsRefinement)
 {
     // Subpixellic refinement of the outer edge points ///////////////////////////
     const float cutLengthOuterPointRefine = 3.f * sqrt(2.f) * scale; // with scale=2^i, i=0..nLevel
@@ -807,14 +807,14 @@ void computeHomographyFromEllipseAndImagedCenter(
  * @return true if the optimization has found a solution, false otherwise.
  */
 bool refineConicFamilyGlob(
-        const int tagIndex,
+        int tagIndex,
         Eigen::Matrix3f & mHomography,
         Point2d<Eigen::Vector3f> & optimalPoint,
         std::vector< cctag::ImageCut > & vCuts, 
         const cv::Mat & src,
         cctag::TagPipe* cudaPipe,
         const cctag::numerical::geometry::Ellipse & outerEllipse,
-        const cctag::Parameters params,
+        const cctag::Parameters & params,
         cctag::NearbyPoint* cctag_pointer_buffer,
         float & residual)
 {
@@ -978,10 +978,10 @@ bool imageCenterOptimizationGlob(
         std::vector< cctag::ImageCut > & vCuts,
         cctag::Point2d<Eigen::Vector3f> & center,
         float & minRes,
-        const float neighbourSize,
+        float neighbourSize,
         const cv::Mat & src, 
         const cctag::numerical::geometry::Ellipse& outerEllipse,
-        const cctag::Parameters params )
+        const cctag::Parameters & params )
 {
     cctag::Point2d<Eigen::Vector3f> optimalPoint;
     Eigen::Matrix3f optimalHomography;
@@ -1166,7 +1166,7 @@ float costFunctionGlob(
  * @return status of the markers (c.f. all the possible status are located in CCTag.hpp) 
  */
 int identify_step_1(
-  const int tagIndex,
+  int tagIndex,
   const CCTag & cctag,
   std::vector<cctag::ImageCut>& vSelectedCuts,
   const cv::Mat &  src,
@@ -1312,7 +1312,7 @@ int identify_step_1(
  * @return status of the markers (c.f. all the possible status are located in CCTag.hpp) 
  */
 int identify_step_2(
-  const int tagIndex,
+  int tagIndex,
   CCTag & cctag,
   std::vector<cctag::ImageCut>& vSelectedCuts,
   const std::vector< std::vector<float> > & radiusRatios, // todo: directly use the CCTagBank

--- a/src/cctag/Identification.hpp
+++ b/src/cctag/Identification.hpp
@@ -56,7 +56,7 @@ enum NeighborType {
  * @return status of the markers (c.f. all the possible status are located in CCTag.hpp) 
  */
 int identify_step_1(
-    const int tagIndex,
+    int tagIndex,
 	const CCTag & cctag,
     std::vector<cctag::ImageCut>& vSelectedCuts,
 	// const std::vector< std::vector<float> > & radiusRatios,
@@ -79,7 +79,7 @@ int identify_step_1(
  * @return status of the markers (c.f. all the possible status are located in CCTag.hpp) 
  */
 int identify_step_2(
-    const int tagIndex,
+    int tagIndex,
 	CCTag & cctag,
     std::vector<cctag::ImageCut>& vSelectedCuts,
 	const std::vector< std::vector<float> > & radiusRatios,
@@ -126,7 +126,7 @@ bool orazioDistanceRobust(
         std::vector<std::list<float> > & vScore,
         const RadiusRatioBank & rrBank,
         const std::vector<cctag::ImageCut> & cuts,
-        const float minIdentProba);
+        float minIdentProba);
 
 /**
  * @brief Extract a rectified 1D signal along an image cut based on an homography.
@@ -148,8 +148,8 @@ void extractSignalUsingHomographyDeprec(
         const cv::Mat & src,
         Eigen::Matrix3f & mHomography,
         std::size_t nSamples = 100,
-        const float begin = 0.f,
-        const float end = 1.f );
+        float begin = 0.f,
+        float end = 1.f );
 
 /**
  * @brief Extract a regularly sampled 1D signal along an image cut.
@@ -164,9 +164,9 @@ void cutInterpolated(
 
 std::pair<float,float> convImageCut(const std::vector<float> & kernel, ImageCut & cut);
 
-void blurImageCut(const float sigma, cctag::ImageCut & cut);
+void blurImageCut(float sigma, cctag::ImageCut & cut);
 
-bool outerEdgeRefinement(ImageCut & cut, const cv::Mat & src, const float scale, const size_t numSamplesOuterEdgePointsRefinement);
+bool outerEdgeRefinement(ImageCut & cut, const cv::Mat & src, float scale, size_t numSamplesOuterEdgePointsRefinement);
 
 /**
  * @brief Collect signals (image cuts) from center to outer ellipse points
@@ -183,8 +183,8 @@ void collectCuts(
         const cv::Mat & src,
         const cctag::Point2d<Eigen::Vector3f> & center,
         const std::vector< cctag::DirectedPoint2d<Eigen::Vector3f> > & outerPoints,
-        const std::size_t sampleCutLength,
-        const std::size_t startOffset );
+        std::size_t sampleCutLength,
+        std::size_t startOffset );
 
 /*
  * @brief Bilinear interpolation for a point whose coordinates are (x,y)
@@ -248,14 +248,14 @@ void getSignals(
  * @return true if the optimization has found a solution, false otherwise.
  */
 bool refineConicFamilyGlob(
-        const int tagIndex,
+        int tagIndex,
         Eigen::Matrix3f & mHomography,
         Point2d<Eigen::Vector3f> & optimalPoint,
         std::vector< cctag::ImageCut > & vCuts, 
         const cv::Mat & src,
         cctag::TagPipe* cudaPipe,
         const cctag::numerical::geometry::Ellipse & outerEllipse,
-        const cctag::Parameters params,
+        const cctag::Parameters & params,
         cctag::NearbyPoint* cctag_pointer_buffer,
         float & residual);
 
@@ -278,10 +278,10 @@ bool imageCenterOptimizationGlob(
         std::vector< cctag::ImageCut > & vCuts,
         cctag::Point2d<Eigen::Vector3f> & center,
         float & minRes,
-        const float neighbourSize,
+        float neighbourSize,
         const cv::Mat & src, 
         const cctag::numerical::geometry::Ellipse & outerEllipse,
-        const cctag::Parameters params );
+        const cctag::Parameters & params );
 
 
 /**
@@ -299,9 +299,9 @@ void getNearbyPoints(
           const cctag::numerical::geometry::Ellipse & ellipse,
           const cctag::Point2d<Eigen::Vector3f> & center,
           std::vector<cctag::Point2d<Eigen::Vector3f> > & nearbyPoints,
-          const float neighbourSize,
-          const std::size_t gridNSample,
-          const NeighborType neighborType);
+          float neighbourSize,
+          std::size_t gridNSample,
+          NeighborType neighborType);
 
 /**
  * @brief Compute an homography (up to a 2D rotation) based on its imaged origin [0,0,1]'
@@ -386,11 +386,11 @@ inline float dis( const float sig, const float val, const float mub, const float
 bool refineConicFamily(
         CCTag & cctag,
         std::vector< cctag::ImageCut > & fsig,
-        const std::size_t lengthSig,
+        std::size_t lengthSig,
         const cv::Mat & src,
         const cctag::numerical::geometry::Ellipse & ellipse,
         const std::vector< cctag::Point2d<Eigen::Vector3f> > & pr,
-        const bool useLmDif );
+        bool useLmDif );
 
 /* depreciated */
 /**
@@ -416,8 +416,8 @@ bool orazioDistance(
         IdSet& idSet,
         const RadiusRatioBank & rrBank,
         const std::vector<cctag::ImageCut> & cuts,
-        const std::size_t startOffset,
-        const float minIdentProba,
+        std::size_t startOffset,
+        float minIdentProba,
         std::size_t sizeIds);
 
 } // namespace identification

--- a/src/cctag/Identification.hpp
+++ b/src/cctag/Identification.hpp
@@ -84,7 +84,7 @@ int identify_step_2(
     std::vector<cctag::ImageCut>& vSelectedCuts,
 	const std::vector< std::vector<float> > & radiusRatios,
 	const cv::Mat & src,
-    cctag::TagPipe* pipe,
+    cctag::TagPipe* cudaPipe,
 	const cctag::Parameters & params);
 
 using RadiusRatioBank = std::vector<std::vector<float>>;
@@ -142,9 +142,9 @@ void extractSignalUsingHomography(
         const Eigen::Matrix3f & mHomography,
         const Eigen::Matrix3f & mInvHomography);
 
-/* depreciated */
+/* deprecated */
 void extractSignalUsingHomographyDeprec(
-        cctag::ImageCut & rectifiedSig,
+        cctag::ImageCut & rectifiedCut,
         const cv::Mat & src,
         Eigen::Matrix3f & mHomography,
         std::size_t nSamples = 100,

--- a/src/cctag/Identification.hpp
+++ b/src/cctag/Identification.hpp
@@ -87,8 +87,8 @@ int identify_step_2(
     cctag::TagPipe* pipe,
 	const cctag::Parameters & params);
 
-typedef std::vector< std::vector<float> > RadiusRatioBank;
-typedef std::vector< std::pair< cctag::Point2d<Eigen::Vector3f>, cctag::ImageCut > > CutSelectionVec;
+using RadiusRatioBank = std::vector<std::vector<float>>;
+using CutSelectionVec =  std::vector< std::pair< cctag::Point2d<Eigen::Vector3f>, cctag::ImageCut>>;
 
 /**
  * @brief Apply a planar homography to a 2D point.
@@ -344,7 +344,7 @@ float costFunctionGlob(
 template<typename VecT>
 typename VecT::value_type computeMedian( const VecT& vec )
 {
-  typedef typename VecT::value_type T;
+  using T = typename VecT::value_type;
   //BOOST_ASSERT( vec.size() > 0 );
 
   const std::size_t s = (vec.size() / 2) + 1;

--- a/src/cctag/ImageCut.hpp
+++ b/src/cctag/ImageCut.hpp
@@ -65,7 +65,7 @@ public:
   
   void setOutOfBounds(const bool outOfBounds) { _outOfBounds = outOfBounds; }
   
-  virtual ~ImageCut() {}
+  virtual ~ImageCut() = default;
   
 private:
   

--- a/src/cctag/ImagePyramid.cpp
+++ b/src/cctag/ImagePyramid.cpp
@@ -20,7 +20,7 @@ ImagePyramid::ImagePyramid()
 {
 }
 
-ImagePyramid::ImagePyramid( std::size_t width, std::size_t height, const std::size_t nLevels, bool cuda_allocates )
+ImagePyramid::ImagePyramid( std::size_t width, std::size_t height, std::size_t nLevels, bool cuda_allocates )
 {
   _levels.clear();
   _levels.resize(nLevels);
@@ -32,7 +32,7 @@ ImagePyramid::ImagePyramid( std::size_t width, std::size_t height, const std::si
   }
 }
 
-void ImagePyramid::build( const cv::Mat & src, const float thrLowCanny, const float thrHighCanny, const cctag::Parameters* params )
+void ImagePyramid::build( const cv::Mat & src, float thrLowCanny, float thrHighCanny, const cctag::Parameters* params )
 {
 #ifdef WITH_CUDA
     if( params->_useCuda ) {
@@ -101,7 +101,7 @@ std::size_t ImagePyramid::getNbLevels() const
   return _levels.size();
 }
 
-Level* ImagePyramid::getLevel( const std::size_t level ) const
+Level* ImagePyramid::getLevel( std::size_t level ) const
 {
         return _levels[level];
 }

--- a/src/cctag/ImagePyramid.cpp
+++ b/src/cctag/ImagePyramid.cpp
@@ -90,9 +90,9 @@ void ImagePyramid::build( const cv::Mat & src, float thrLowCanny, float thrHighC
 
 ImagePyramid::~ImagePyramid()
 {
-  for(int i = 0; i < _levels.size() ; ++i)
+  for(auto & _level : _levels)
   {
-    delete _levels[i];
+    delete _level;
   }
 };
 

--- a/src/cctag/ImagePyramid.hpp
+++ b/src/cctag/ImagePyramid.hpp
@@ -12,7 +12,7 @@
 
 #include <opencv2/opencv.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <vector>
 

--- a/src/cctag/ImagePyramid.hpp
+++ b/src/cctag/ImagePyramid.hpp
@@ -25,17 +25,17 @@ class ImagePyramid
 public:
   ImagePyramid();
   
-  ImagePyramid( const std::size_t width, const std::size_t height, const std::size_t nLevels, bool cuda_allocates );
+  ImagePyramid( std::size_t width, std::size_t height, std::size_t nLevels, bool cuda_allocates );
   
   ~ImagePyramid();
 
-  Level* getLevel( const std::size_t level ) const;
+  Level* getLevel( std::size_t level ) const;
   
   std::size_t getNbLevels() const;
   
     /* The pyramid building function is never called if CUDA is used.
      */
-  void build(const cv::Mat & src, const float thrLowCanny, const float thrHighCanny, const cctag::Parameters* params );
+  void build(const cv::Mat & src, float thrLowCanny, float thrHighCanny, const cctag::Parameters* params );
 
 private:
   std::vector<Level*> _levels;

--- a/src/cctag/Level.cpp
+++ b/src/cctag/Level.cpp
@@ -54,8 +54,8 @@ Level::~Level( )
 }
 
 void Level::setLevel( const cv::Mat & src,
-                      const float thrLowCanny,
-                      const float thrHighCanny,
+                      float thrLowCanny,
+                      float thrHighCanny,
                       const cctag::Parameters* params )
 {
     if( _cuda_allocates ) {

--- a/src/cctag/Level.cpp
+++ b/src/cctag/Level.cpp
@@ -15,8 +15,8 @@
 
 namespace cctag {
 
-Level::Level( std::size_t width, std::size_t height, int level, bool cuda_allocates )
-    : _level( level )
+Level::Level( std::size_t width, std::size_t height, int debug_info_level, bool cuda_allocates )
+    : _level( debug_info_level )
     , _cuda_allocates( cuda_allocates )
     , _mat_initialized_from_cuda( false )
     , _cols( width )

--- a/src/cctag/Level.cpp
+++ b/src/cctag/Level.cpp
@@ -23,11 +23,11 @@ Level::Level( std::size_t width, std::size_t height, int level, bool cuda_alloca
     , _rows( height )
 {
     if( _cuda_allocates ) {
-        _src   = 0;
-        _dx    = 0;
-        _dy    = 0;
-        _mag   = 0;
-        _edges = 0;
+        _src   = nullptr;
+        _dx    = nullptr;
+        _dy    = nullptr;
+        _mag   = nullptr;
+        _edges = nullptr;
     } else {
         // Allocation
         _src   = new cv::Mat(height, width, CV_8UC1);

--- a/src/cctag/Level.hpp
+++ b/src/cctag/Level.hpp
@@ -27,8 +27,8 @@ public:
   ~Level( );
 
   void setLevel( const cv::Mat & src,
-                 const float thrLowCanny,
-                 const float thrHighCanny,
+                 float thrLowCanny,
+                 float thrHighCanny,
                  const cctag::Parameters* params );
 #ifdef WITH_CUDA
   void setLevel( cctag::TagPipe* cuda_pipe,

--- a/src/cctag/Multiresolution.cpp
+++ b/src/cctag/Multiresolution.cpp
@@ -369,10 +369,9 @@ void cctagMultiresDetection(
 
         for(EdgePoint * e : rescaledOuterEllipsePoints)
         {
-          rescaledOuterEllipsePointsDouble.push_back(
-                  DirectedPoint2d<Eigen::Vector3f>(e->x(), e->y(),
+          rescaledOuterEllipsePointsDouble.emplace_back(e->x(), e->y(),
                   e->dX(),
-                  e->dY())
+                  e->dY()
           );
           
           CCTagVisualDebug::instance().drawPoint(Point2d<Eigen::Vector3f>(e->x(), e->y()), cctag::color_red);

--- a/src/cctag/Multiresolution.cpp
+++ b/src/cctag/Multiresolution.cpp
@@ -269,7 +269,7 @@ void cctagMultiresDetection(
         CCTag::List& markers,
         const cv::Mat& imgGraySrc,
         const ImagePyramid& imagePyramid,
-        const std::size_t   frame,
+        std::size_t   frame,
         cctag::TagPipe*    cuda_pipe,
         const Parameters&   params,
         cctag::logtime::Mgmt* durations )

--- a/src/cctag/Multiresolution.cpp
+++ b/src/cctag/Multiresolution.cpp
@@ -175,7 +175,7 @@ void update(
 {
   bool flag = false;
 
-  BOOST_FOREACH(CCTag & currentMarker, markers)
+  for(CCTag & currentMarker : markers)
   {
     if ( ( currentMarker.getStatus() > 0 ) && ( markerToAdd.getStatus() > 0 ) && currentMarker.isEqual(markerToAdd) )
     {
@@ -259,7 +259,7 @@ static void cctagMultiresDetection_inner(
     outFilename2 << "viewLevel" << i;
     CCTagVisualDebug::instance().newSession(outFilename2.str());
 
-    BOOST_FOREACH(const CCTag & marker, pyramidMarkers)
+    for(const CCTag & marker : pyramidMarkers)
     {
         CCTagVisualDebug::instance().drawMarker(marker, false);
     }
@@ -317,7 +317,7 @@ void cctagMultiresDetection(
   CCTagVisualDebug::instance().newSession("multiresolution");
 
   // Project markers from the top of the pyramid to the bottom (original image).
-  BOOST_FOREACH(CCTag & marker, markers)
+  for(CCTag & marker : markers)
   {
     int i = marker.pyramidLevel();
     // if the marker has to be rescaled into the original image
@@ -367,7 +367,7 @@ void cctagMultiresDetection(
         std::vector< DirectedPoint2d<Eigen::Vector3f> > rescaledOuterEllipsePointsDouble;
         std::size_t numCircles = params._nCrowns * 2;
 
-        BOOST_FOREACH(EdgePoint * e, rescaledOuterEllipsePoints)
+        for(EdgePoint * e : rescaledOuterEllipsePoints)
         {
           rescaledOuterEllipsePointsDouble.push_back(
                   DirectedPoint2d<Eigen::Vector3f>(e->x(), e->y(),
@@ -395,7 +395,7 @@ void cctagMultiresDetection(
   
   // Log
   CCTagFileDebug::instance().newSession("data.txt");
-  BOOST_FOREACH(const CCTag & marker, markers)
+  for(const CCTag & marker : markers)
   {
     CCTagFileDebug::instance().outputMarkerInfos(marker);
   }

--- a/src/cctag/Multiresolution.hpp
+++ b/src/cctag/Multiresolution.hpp
@@ -41,7 +41,7 @@ void cctagMultiresDetection(
         CCTag::List& markers,
         const cv::Mat& imgGraySrc,
         const ImagePyramid& imagePyramid,
-        const std::size_t   frame,
+        std::size_t   frame,
         cctag::TagPipe*    cuda_pipe,
         const Parameters&   params,
         cctag::logtime::Mgmt* durations );

--- a/src/cctag/Params.cpp
+++ b/src/cctag/Params.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "Params.hpp"
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <boost/archive/xml_iarchive.hpp>

--- a/src/cctag/Params.cpp
+++ b/src/cctag/Params.cpp
@@ -32,7 +32,7 @@ void Parameters::LoadOverride()
   std::cout << "CCTag: loaded parameters override file: " << path << std::endl;
 }
 
-Parameters::Parameters(const std::size_t nCrowns)
+Parameters::Parameters(std::size_t nCrowns)
     : _cannyThrLow( kDefaultCannyThrLow )
     , _cannyThrHigh( kDefaultCannyThrHigh )
     , _distSearch( kDefaultDistSearch )

--- a/src/cctag/Params.hpp
+++ b/src/cctag/Params.hpp
@@ -108,7 +108,7 @@ struct Parameters
   static Parameters Override;
   static void LoadOverride();
 
-  explicit Parameters(const std::size_t nCrowns = kDefaultNCrowns);
+  explicit Parameters(std::size_t nCrowns = kDefaultNCrowns);
 
   float _cannyThrLow; // canny low threshold
   float _cannyThrHigh; // canny high threshold

--- a/src/cctag/Params.hpp
+++ b/src/cctag/Params.hpp
@@ -108,7 +108,7 @@ struct Parameters
   static Parameters Override;
   static void LoadOverride();
 
-  Parameters(const std::size_t nCrowns = kDefaultNCrowns);
+  explicit Parameters(const std::size_t nCrowns = kDefaultNCrowns);
 
   float _cannyThrLow; // canny low threshold
   float _cannyThrHigh; // canny high threshold

--- a/src/cctag/SubPixEdgeOptimizer.cpp
+++ b/src/cctag/SubPixEdgeOptimizer.cpp
@@ -26,7 +26,7 @@
 
 namespace cctag {
 
-#if defined(WITH_OPTPP) && defined(SUBPIX_EDGE_OPTIM) // undefined. Depreciated
+#if defined(WITH_OPTPP) && defined(SUBPIX_EDGE_OPTIM) // undefined. Deprecated
 
 SubPixEdgeOptimizer::SubPixEdgeOptimizer( const cctag::ImageCut & line )
 : Parent( 4, &SubPixEdgeOptimizer::subPix, NULL, this )

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -100,11 +100,9 @@ void vote(EdgePointCollection& edgeCollection,
     }
 
     
-    for (int iEdgePoint = 0; iEdgePoint < pointCount; ++iEdgePoint ) {
+    for (int iEdgePoint = 0; iEdgePoint < pointCount; ++iEdgePoint )
+    {
         EdgePoint& p = *edgeCollection(iEdgePoint);
-        float lastDist, dist, totalDistance; // scalar to compute the distance ratio
-        float cosDiffTheta; // difference in subsequent gradients orientation
-        std::size_t i = 1;
         
         // Alternate from the edge point found in the direction opposed to the gradient
         // direction.
@@ -115,65 +113,81 @@ void vote(EdgePointCollection& edgeCollection,
         // To save all sub-segments length
         std::vector<float> vDist; ///
         vDist.reserve(params._nCrowns * 2 - 1);
-        int flagDist = 1;
 
         // Length of the reconstructed field line approximation between the two
         // extremities.
-        totalDistance = 0.f;
+        float totalDistance = 0.f;
 
-        if (current) {
-            cosDiffTheta = -p.gradient().dot(current->gradient());
-            if (cosDiffTheta >= params._angleVoting) {
-                lastDist = cctag::numerical::distancePoints2D(p, *current);
+        if (current != nullptr)
+        {
+            // difference in subsequent gradients orientation
+            float cosDiffTheta = -p.gradient().dot(current->gradient());
+            if (cosDiffTheta >= params._angleVoting)
+            {
+                float lastDist = cctag::numerical::distancePoints2D(p, *current);
                 vDist.push_back(lastDist);
                 
                 // Add the sub-segment length to the total distance.
                 totalDistance += lastDist;
 
+                std::size_t i = 1;
                 // Iterate over all crowns
-                while (i < params._nCrowns) {
+                while (i < params._nCrowns)
+                {
                     choosen = nullptr;
                     
                     // First in the gradient direction
                     EdgePoint* target = edgeCollection.after(current);
                     // No edge point was found in that direction
-                    if (!target) {
+                    if (target == nullptr)
+                    {
                         break;
                     }
                     
                     // Check the difference of two consecutive angles
                     cosDiffTheta = -target->gradient().dot(current->gradient());
-                    if (cosDiffTheta >= params._angleVoting) {
-                        dist = cctag::numerical::distancePoints2D(*target, *current);
+                    if (cosDiffTheta >= params._angleVoting)
+                    {
+                        // scalar used to compute the distance ratio
+                        float dist = cctag::numerical::distancePoints2D(*target, *current);
                         vDist.push_back(dist);
                         totalDistance += dist;
 
+                        int flagDist = 1;
+
                         // Check the distance ratio
-                        if (vDist.size() > 1) {
-                            for (int iDist = 0; iDist < vDist.size(); ++iDist) {
-                                for (int jDist = iDist + 1; jDist < vDist.size(); ++jDist) {
+                        if (vDist.size() > 1)
+                        {
+                            for (int iDist = 0; iDist < vDist.size(); ++iDist)
+                            {
+                                for (int jDist = iDist + 1; jDist < vDist.size(); ++jDist)
+                                {
                                     flagDist = (vDist[iDist] <= vDist[jDist] * params._ratioVoting) && (vDist[jDist] <= vDist[iDist] * params._ratioVoting) && flagDist;
                                 }
                             }
                         }
 
-                        if (flagDist)
+                        if (flagDist != 0)
                         {
                             lastDist = dist;
                             current = target;
                             // Second in the opposite gradient direction
                             target = edgeCollection.before(current);
-                            if (!target) {
+                            if (target == nullptr)
+                            {
                                 break;
                             }
                             cosDiffTheta = -target->gradient().dot(current->gradient());
-                            if (cosDiffTheta >= params._angleVoting) {
+                            if (cosDiffTheta >= params._angleVoting)
+                            {
                                 dist = cctag::numerical::distancePoints2D(*target, *current);
                                 vDist.push_back(dist);
                                 totalDistance += dist;
 
-                                for (int iDist = 0; iDist < vDist.size(); ++iDist) {
-                                    for (int jDist = iDist + 1; jDist < vDist.size(); ++jDist) {
+                                for (int iDist = 0; iDist < vDist.size(); ++iDist)
+                                {
+                                    for (int jDist = iDist + 1; jDist < vDist.size(); ++jDist)
+                                    {
                                         flagDist = (vDist[iDist] <= vDist[jDist] * params._ratioVoting) && (vDist[jDist] <= vDist[iDist] * params._ratioVoting) && flagDist;
                                     }
                                 }
@@ -183,27 +197,37 @@ void vote(EdgePointCollection& edgeCollection,
                                     lastDist = dist;
                                     current = target;
                                     choosen = current;
-                                    if (!current) {
+                                    if (current == nullptr)
+                                    {
                                         break;
                                     }
-                                } else {
+                                }
+                                else
+                                {
                                     break;
                                 }
-                            } else {
+                            }
+                            else
+                            {
                                 break;
                             }
-                        } else {
+                        }
+                        else
+                        {
                             break;
                         }
-                    } else {
+                    }
+                    else
+                    {
                         break;
                     }
                     ++i;
-                }
+                } // while
             }
         }
         // Check if winner was found
-        if (choosen) {
+        if (choosen != nullptr)
+        {
             int iChoosen = edgeCollection(choosen);
             voters[iChoosen].push_back(edgeCollection(&p));
             // update flow length average scale factor
@@ -342,21 +366,31 @@ void vote(EdgePointCollection& edgeCollection,
             ++i;
         }
 
-        int n = 0;
-        if ((i == maxLength) || (stop == CONVEXITY_LOST)) {
-            if (convexEdgeSegment.size() > windowSizeOnInnerEllipticSegment) {
-                for(EdgePoint * collectedP : convexEdgeSegment) {
-                    if (n == convexEdgeSegment.size() - windowSizeOnInnerEllipticSegment) {
+        if ((i == maxLength) || (stop == CONVEXITY_LOST))
+        {
+            if (convexEdgeSegment.size() > windowSizeOnInnerEllipticSegment)
+            {
+                int n = 0;
+                for(EdgePoint * collectedP : convexEdgeSegment)
+                {
+                    if (n == convexEdgeSegment.size() - windowSizeOnInnerEllipticSegment)
+                    {
                         break;
-                    } else {
+                    }
+                    else
+                    {
                         edgeCollection.set_processed_in(collectedP, true);
                         ++n;
                     }
                 }
             }
-        } else if (stop == EDGE_NOT_FOUND) {
+        }
+        else if (stop == EDGE_NOT_FOUND)
+        {
             for (EdgePoint* collectedP : convexEdgeSegment)
-              edgeCollection.set_processed_in(collectedP, true);
+            {
+                edgeCollection.set_processed_in(collectedP, true);
+            }
         }
         return;
     }

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -247,8 +247,13 @@ void vote(EdgePointCollection& edgeCollection,
         }
     }
     
-    void edgeLinkingDir(EdgePointCollection& edgeCollection, boost::container::flat_set<unsigned int>& processed, const EdgePoint* p, const int dir,
-            std::list<EdgePoint*>& convexEdgeSegment, std::size_t windowSizeOnInnerEllipticSegment, float averageVoteMin) {
+    void edgeLinkingDir(EdgePointCollection& edgeCollection,
+                        boost::container::flat_set<unsigned int>& processed,
+                        const EdgePoint* p,
+                        int dir,
+                        std::list<EdgePoint*>& convexEdgeSegment,
+                        std::size_t windowSizeOnInnerEllipticSegment,
+                        float averageVoteMin) {
         
         std::deque<float> phi;
         std::size_t i = 0;
@@ -380,7 +385,7 @@ void vote(EdgePointCollection& edgeCollection,
             float & SmFinal,
             float threshold,
             std::size_t weightedType,
-            const std::size_t maxSize)
+            std::size_t maxSize)
     {
       
       filteredChildrens.reserve(childrens.size());

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -340,7 +340,7 @@ void vote(EdgePointCollection& edgeCollection,
         int n = 0;
         if ((i == maxLength) || (stop == CONVEXITY_LOST)) {
             if (convexEdgeSegment.size() > windowSizeOnInnerEllipticSegment) {
-                BOOST_FOREACH(EdgePoint * collectedP, convexEdgeSegment) {
+                for(EdgePoint * collectedP : convexEdgeSegment) {
                     if (n == convexEdgeSegment.size() - windowSizeOnInnerEllipticSegment) {
                         break;
                     } else {
@@ -511,7 +511,7 @@ void vote(EdgePointCollection& edgeCollection,
             vDistFinal.clear();
             vDistFinal.reserve(childrens.size());
 
-            BOOST_FOREACH(EdgePoint * e, childrens) {
+            for(EdgePoint * e : childrens) {
 
                 float distFinal = 1e300;
 
@@ -663,7 +663,7 @@ void vote(EdgePointCollection& edgeCollection,
                 std::vector<float> vDistFinal;
                 vDistFinal.reserve(outerEllipsePointsTemp.size());
 
-                BOOST_FOREACH(EdgePoint * p, outerEllipsePointsTemp) {
+                for(EdgePoint * p : outerEllipsePointsTemp) {
                     float distFinal = numerical::distancePointEllipse(*p, outerEllipseTemp);
                     vDistFinal.push_back(distFinal);
                 }

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -413,7 +413,7 @@ void vote(EdgePointCollection& edgeCollection,
               if (iEdgePoint == std::size_t(k*step) )
               {
                 ++k;
-                pts.push_back(edgePoint->cast<float>());
+                pts.emplace_back(edgePoint->cast<float>());
                 CCTagVisualDebug::instance().drawPoint(cctag::Point2d<Eigen::Vector3f>(pts.back()), cctag::color_red);
 
                 if (weightedType == INV_GRAD_WEIGHT) {
@@ -553,7 +553,7 @@ void vote(EdgePointCollection& edgeCollection,
         std::vector<Eigen::Vector3f> pts;
         pts.reserve(outerEllipsePoints.size());
         for (std::vector<EdgePoint*>::iterator it = outerEllipsePoints.begin(); it != outerEllipsePoints.end(); ++it) {
-            pts.push_back((*it)->cast<float>());
+            pts.emplace_back((*it)->cast<float>());
         }
 
         // Copy/Align content of anotherOuterEllipsePoints
@@ -561,7 +561,7 @@ void vote(EdgePointCollection& edgeCollection,
         anotherPts.reserve(anotherOuterEllipsePoints.size());
         for (std::vector<EdgePoint*>::const_iterator it = anotherOuterEllipsePoints.begin(); it != anotherOuterEllipsePoints.end(); ++it) {
             // todo@Lilian: avoid copy, idem in outlierRemoval
-            anotherPts.push_back((*it)->cast<float>());
+            anotherPts.emplace_back((*it)->cast<float>());
         }
 
         std::vector<float> distRef;
@@ -582,7 +582,7 @@ void vote(EdgePointCollection& edgeCollection,
             
             auto it = permutations.begin();
             for (size_t i = 0; i < 4; ++i) {
-                points.push_back(Point2d<Eigen::Vector3f>(float(pts[*it](0)), float(pts[*it](1))));
+                points.emplace_back(float(pts[*it](0)), float(pts[*it](1)));
                 ++it;
             }
 
@@ -590,7 +590,7 @@ void vote(EdgePointCollection& edgeCollection,
 
             it = permutations.begin();
             for (size_t i = 0; i < 4; ++i) {
-                points.push_back(Point2d<Eigen::Vector3f>(float(anotherOuterEllipsePoints[*it]->x()), float(anotherOuterEllipsePoints[*it]->y())));
+                points.emplace_back(float(anotherOuterEllipsePoints[*it]->x()), float(anotherOuterEllipsePoints[*it]->y()));
                 ++it;
             }
 

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -557,16 +557,18 @@ void vote(EdgePointCollection& edgeCollection,
         // Copy/Align content of outerEllipsePoints
         std::vector<Eigen::Vector3f> pts;
         pts.reserve(outerEllipsePoints.size());
-        for (std::vector<EdgePoint*>::iterator it = outerEllipsePoints.begin(); it != outerEllipsePoints.end(); ++it) {
-            pts.emplace_back((*it)->cast<float>());
+        for(const auto & outerEllipsePoint : outerEllipsePoints)
+        {
+            pts.push_back(outerEllipsePoint->cast<float>());
         }
 
         // Copy/Align content of anotherOuterEllipsePoints
         std::vector<Eigen::Vector3f> anotherPts;
         anotherPts.reserve(anotherOuterEllipsePoints.size());
-        for (std::vector<EdgePoint*>::const_iterator it = anotherOuterEllipsePoints.begin(); it != anotherOuterEllipsePoints.end(); ++it) {
+        for(const auto & anotherOuterEllipsePoint : anotherOuterEllipsePoints)
+        {
             // todo@Lilian: avoid copy, idem in outlierRemoval
-            anotherPts.emplace_back((*it)->cast<float>());
+            anotherPts.push_back(anotherOuterEllipsePoint->cast<float>());
         }
 
         std::vector<float> distRef;

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -110,7 +110,7 @@ void vote(EdgePointCollection& edgeCollection,
         // direction.
         EdgePoint* current = edgeCollection.before(&p);
         // Here current contains the edge point lying on the 2nd ellipse (from outer to inner)
-        EdgePoint* choosen = NULL;
+        EdgePoint* choosen = nullptr;
 
         // To save all sub-segments length
         std::vector<float> vDist; ///
@@ -132,7 +132,7 @@ void vote(EdgePointCollection& edgeCollection,
 
                 // Iterate over all crowns
                 while (i < params._nCrowns) {
-                    choosen = NULL;
+                    choosen = nullptr;
                     
                     // First in the gradient direction
                     EdgePoint* target = edgeCollection.after(current);

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -395,7 +395,7 @@ void vote(EdgePointCollection& edgeCollection,
         return;
     }
 
-    void childrensOf(const EdgePointCollection& edgeCollection, const std::list<EdgePoint*>& edges, std::list<EdgePoint*>& childrens) {
+    void childrenOf(const EdgePointCollection& edgeCollection, const std::list<EdgePoint*>& edges, std::list<EdgePoint*>& children) {
         std::size_t voteMax = 1;
 
         for (const EdgePoint* e : edges) {
@@ -408,24 +408,24 @@ void vote(EdgePointCollection& edgeCollection,
 
                 if (voters.second - voters.first >= voteMax / 14)
                 for (; voters.first != voters.second; ++voters.first)
-                  childrens.push_back(edgeCollection(*voters.first));
+                  children.push_back(edgeCollection(*voters.first));
             }
         }
     }
 
     void outlierRemoval(
-            const std::list<EdgePoint*>& childrens,
-            std::vector<EdgePoint*>& filteredChildrens,
+            const std::list<EdgePoint*>& children,
+            std::vector<EdgePoint*>& filteredChildren,
             float & SmFinal,
             float threshold,
             std::size_t weightedType,
             std::size_t maxSize)
     {
       
-      filteredChildrens.reserve(childrens.size());
+      filteredChildren.reserve(children.size());
       
-      const std::size_t nSubsampleSize = std::min(childrens.size(), maxSize);
-      const float step = (float) childrens.size()/ (float) nSubsampleSize;    
+      const std::size_t nSubsampleSize = std::min(children.size(), maxSize);
+      const float step = (float) children.size()/ (float) nSubsampleSize;
 
         // Precondition
         if (nSubsampleSize >= 5) {
@@ -434,10 +434,10 @@ void vote(EdgePointCollection& edgeCollection,
             const float f = 1.f;
 
             std::vector<Eigen::Vector3f> pts;
-            pts.reserve(childrens.size());
+            pts.reserve(children.size());
 
             std::vector<float> weights;
-            weights.reserve(childrens.size());
+            weights.reserve(children.size());
 
             // Store a subset of EdgePoint* on which the robust ellipse estimation will
             // performed. Considering a subset of points is valid as what matters is the 
@@ -447,7 +447,7 @@ void vote(EdgePointCollection& edgeCollection,
 
             std::size_t k = 0;
             std::size_t iEdgePoint = 0;
-            for(const auto edgePoint : childrens )
+            for(const auto edgePoint : children )
             {
               if (iEdgePoint == std::size_t(k*step) )
               {
@@ -548,9 +548,9 @@ void vote(EdgePointCollection& edgeCollection,
 
             std::vector<float> vDistFinal;
             vDistFinal.clear();
-            vDistFinal.reserve(childrens.size());
+            vDistFinal.reserve(children.size());
 
-            for(EdgePoint * e : childrens) {
+            for(EdgePoint * e : children) {
 
                 float distFinal = 1e300;
 
@@ -564,7 +564,7 @@ void vote(EdgePointCollection& edgeCollection,
  
                 if (distFinal < threshold * Sm) {
 
-                    filteredChildrens.push_back(e);
+                    filteredChildren.push_back(e);
                     vDistFinal.push_back(distFinal);
                 }
             }
@@ -576,7 +576,7 @@ void vote(EdgePointCollection& edgeCollection,
             EdgePointCollection& edgeCollection,
             numerical::geometry::Ellipse & outerEllipse,
             std::vector<EdgePoint*>& outerEllipsePoints,
-            const std::vector<EdgePoint*>& filteredChildrens,
+            const std::vector<EdgePoint*>& filteredChildren,
             const Candidate & anotherCandidate,
             std::vector< std::vector< DirectedPoint2d<Eigen::Vector3f> > >& cctagPoints,
             std::size_t numCircles,
@@ -711,7 +711,7 @@ void vote(EdgePointCollection& edgeCollection,
                 const float SmFinal = numerical::medianRef(vDistFinal);
 
                 if (SmFinal < thrMedianDistanceEllipse) {
-                    if (addCandidateFlowtoCCTag(edgeCollection, anotherCandidate._filteredChildrens, anotherOuterEllipsePoints, outerEllipseTemp, cctagPoints, numCircles)) {
+                    if (addCandidateFlowtoCCTag(edgeCollection, anotherCandidate._filteredChildren, anotherOuterEllipsePoints, outerEllipseTemp, cctagPoints, numCircles)) {
                         outerEllipsePoints = outerEllipsePointsTemp;
                         outerEllipse = outerEllipseTemp;
 

--- a/src/cctag/Vote.hpp
+++ b/src/cctag/Vote.hpp
@@ -54,24 +54,24 @@ void edgeLinkingDir(EdgePointCollection& edgeCollection, boost::container::flat_
 	const EdgePoint* p, int dir, std::list<EdgePoint*>& convexEdgeSegment,
 	std::size_t windowSizeOnInnerEllipticSegment, float averageVoteMin);
 
-/** @brief Concaten all childrens of each points
+/** @brief Concaten all children of each points
  * @param edges list of edges
- * @param childrens resulting childrens
+ * @param children resulting children
  */
-void childrensOf(const EdgePointCollection& edgeCollection, const std::list<EdgePoint*>& edges, std::list<EdgePoint*>& childrens );
+void childrenOf(const EdgePointCollection& edgeCollection, const std::list<EdgePoint*>& edges, std::list<EdgePoint*>& children );
 
-/** @brief Concaten all childrens of each points
- * @param [in/out] edges list of childrens points (from a winner)
+/** @brief Concaten all children of each points
+ * @param [in/out] edges list of children points (from a winner)
  */
 void outlierRemoval(
-        const std::list<EdgePoint*>& childrens,
-        std::vector<EdgePoint*>& filteredChildrens,
+        const std::list<EdgePoint*>& children,
+        std::vector<EdgePoint*>& filteredChildren,
         float & SmFinal,
         float threshold,
         std::size_t weightedType = NO_WEIGHT,
         std::size_t maxSize = std::numeric_limits<std::size_t>::max());
 
-//void outlierRemoval( std::vector<EdgePoint*>& childrens, float & SmFinal, float threshold, std::size_t weightedType = 0 ); //todo@Lilian : templater le outlierRemoval
+//void outlierRemoval( std::vector<EdgePoint*>& children, float & SmFinal, float threshold, std::size_t weightedType = 0 ); //todo@Lilian : templater le outlierRemoval
 
 /** @brief Search for another segment after the ellipse growinf procedure
  * @param points from the first elliptical segment
@@ -81,7 +81,7 @@ bool isAnotherSegment(
         EdgePointCollection& edgeCollection,
         numerical::geometry::Ellipse & outerEllipse,
         std::vector<EdgePoint*>&  outerEllipsePoints,
-        const std::vector<EdgePoint*>& filteredChildrens,
+        const std::vector<EdgePoint*>& filteredChildren,
         const Candidate & anotherCandidate,
         std::vector< std::vector< DirectedPoint2d<Eigen::Vector3f> > >& cctagPoints,
         std::size_t numCircles,

--- a/src/cctag/Vote.hpp
+++ b/src/cctag/Vote.hpp
@@ -51,7 +51,7 @@ void edgeLinking(EdgePointCollection& edgeCollection, std::list<EdgePoint*>& con
  * @param edges resulting edges sorted points
  */
 void edgeLinkingDir(EdgePointCollection& edgeCollection, boost::container::flat_set<unsigned int>& processed,
-	const EdgePoint* p, const int dir, std::list<EdgePoint*>& convexEdgeSegment,
+	const EdgePoint* p, int dir, std::list<EdgePoint*>& convexEdgeSegment,
 	std::size_t windowSizeOnInnerEllipticSegment, float averageVoteMin);
 
 /** @brief Concaten all childrens of each points
@@ -69,7 +69,7 @@ void outlierRemoval(
         float & SmFinal,
         float threshold,
         std::size_t weightedType = NO_WEIGHT,
-        const std::size_t maxSize = std::numeric_limits<int>::max());
+        std::size_t maxSize = std::numeric_limits<std::size_t>::max());
 
 //void outlierRemoval( std::vector<EdgePoint*>& childrens, float & SmFinal, float threshold, std::size_t weightedType = 0 ); //todo@Lilian : templater le outlierRemoval
 

--- a/src/cctag/cuda/debug_image.h
+++ b/src/cctag/cuda/debug_image.h
@@ -48,10 +48,10 @@ public:
 
     struct RandomColorMap
     {
-        typedef unsigned char                 Byte_t;
-        typedef std::map<Byte_t,RandomColor>  map_t;
-        typedef map_t::iterator               it_t;
-        typedef std::pair<Byte_t,RandomColor> pair_t;
+        using Byte_t = unsigned char;
+        using map_t = std::map<Byte_t,RandomColor>;
+        using it_t = map_t::iterator;
+        using pair_t = std::pair<Byte_t,RandomColor>;
 
         map_t random_mapping;
 

--- a/src/cctag/cuda/device_prop.hpp
+++ b/src/cctag/cuda/device_prop.hpp
@@ -17,7 +17,7 @@ class device_prop_t
     int _num_devices;
     std::vector<cudaDeviceProp*> _properties;
 public:
-    device_prop_t( bool output = false );
+    explicit device_prop_t( bool output = false );
     ~device_prop_t( );
 
     void print( );

--- a/src/cctag/cuda/frame_07_vote.h
+++ b/src/cctag/cuda/frame_07_vote.h
@@ -26,12 +26,12 @@
 
 namespace cv {
     namespace cuda {
-        typedef PtrStepSz<int16_t>  PtrStepSz16s;
-        typedef PtrStepSz<uint32_t> PtrStepSz32u;
-        typedef PtrStepSz<int32_t>  PtrStepSz32s;
-        typedef PtrStep<int16_t>    PtrStep16s;
-        typedef PtrStep<uint32_t>   PtrStep32u;
-        typedef PtrStep<int32_t>    PtrStep32s;
+        using PtrStepSz16s = PtrStepSz<int16_t>;
+        using PtrStepSz32u = PtrStepSz<uint32_t>;
+        using PtrStepSz32s = PtrStepSz<int32_t>;
+        using PtrStep16s = PtrStep<int16_t>;
+        using PtrStep32u = PtrStep<uint32_t>;
+        using PtrStep32s = PtrStep<int32_t>;
     }
 };
 

--- a/src/cctag/cuda/geom_matrix.h
+++ b/src/cctag/cuda/geom_matrix.h
@@ -20,7 +20,7 @@ class matrix3x3
 
 public:
     __host__ __device__
-    matrix3x3( ) { }
+    matrix3x3( ) = default;
 
     // Note: default copy contructor and
     //       default assignment operator

--- a/src/cctag/cuda/ptrstep.h
+++ b/src/cctag/cuda/ptrstep.h
@@ -14,24 +14,24 @@
 
 namespace cv {
     namespace cuda {
-        typedef PtrStepSz<int16_t>  PtrStepSz16s;
-        typedef PtrStepSz<uint32_t> PtrStepSz32u;
-        typedef PtrStepSz<int32_t>  PtrStepSz32s;
-        typedef PtrStepSz<uchar4>   PtrStepSzb4;
+        using PtrStepSz16s       = PtrStepSz<int16_t>;
+        using PtrStepSz32u       = PtrStepSz<uint32_t>;
+        using PtrStepSz32s       = PtrStepSz<int32_t>;
+        using PtrStepSzb4        = PtrStepSz<uchar4>;
 
-        typedef PtrStep<int16_t>    PtrStep16s;
-        typedef PtrStep<uint32_t>   PtrStep32u;
-        typedef PtrStep<int32_t>    PtrStep32s;
-        typedef PtrStep<uchar4>     PtrStepb4;
+        using PtrStep16s         = PtrStep<int16_t>;
+        using PtrStep32u         = PtrStep<uint32_t>;
+        using PtrStep32s         = PtrStep<int32_t>;
+        using PtrStepb4          = PtrStep<uchar4>;
 
 #ifdef DEBUG_LINKED_USE_INT4_BUFFER
-        typedef PtrStepSz<int4>     PtrStepSzInt2;
-        typedef PtrStep<int4>       PtrStepInt2;
-        typedef int4                PtrStepInt2_base_t;
+        using PtrStepSzInt2      = PtrStepSz<int4>;
+        using PtrStepInt2        = PtrStep<int4>;
+        using PtrStepInt2_base_t = int4;
 #else // DEBUG_LINKED_USE_INT4_BUFFER
-        typedef PtrStepSz<int2>     PtrStepSzInt2;
-        typedef PtrStep<int2>       PtrStepInt2;
-        typedef int2                PtrStepInt2_base_t;
+        using PtrStepSzInt2      = PtrStepSz<int2>;
+        using PtrStepInt2        = PtrStep<int2>;
+        using PtrStepInt2_base_t = int2;
 #endif // DEBUG_LINKED_USE_INT4_BUFFER
     }
 };

--- a/src/cctag/filter/cvRecode.cpp
+++ b/src/cctag/filter/cvRecode.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/timer.hpp>
 
-#include <stdlib.h> // for ::abs
+#include <cstdlib> // for ::abs
 #include <climits>
 #include <cmath>
 #include <cstddef>

--- a/src/cctag/filter/cvRecode.cpp
+++ b/src/cctag/filter/cvRecode.cpp
@@ -59,7 +59,7 @@ void cvRecodedCanny(
   
   boost::timer t;  
   std::vector<uchar*> stack;
-  uchar** stack_top = 0, ** stack_bottom = 0;
+  uchar** stack_top = nullptr, ** stack_bottom = nullptr;
   
   CvSize size;
   int flags = aperture_size;
@@ -374,8 +374,8 @@ void cvRecodedCanny(
 #else // USE_INTEGER_REP
   std::vector<float> mag_collect;
 #endif // USE_INTEGER_REP
-  std::ofstream* mag_img_file  = 0;
-  std::ofstream* hyst_img_file = 0;
+  std::ofstream* mag_img_file  = nullptr;
+  std::ofstream* hyst_img_file = nullptr;
 
 #ifdef WITH_CUDE
   if( params->_debugDir == "" ) {

--- a/src/cctag/geometry/Circle.cpp
+++ b/src/cctag/geometry/Circle.cpp
@@ -14,12 +14,12 @@ namespace cctag {
 namespace numerical {
 namespace geometry {
 
-Circle::Circle( const Point2d<Eigen::Vector3f>& center, const float r )
+Circle::Circle( const Point2d<Eigen::Vector3f>& center, float r )
 	: Ellipse( center, r, r, 0.f )
 {
 }
 
-Circle::Circle( const float r )
+Circle::Circle( float r )
 	: Ellipse( Point2d<Eigen::Vector3f>(0.f, 0.f) , r, r, 0.f )
 {
 }

--- a/src/cctag/geometry/Circle.hpp
+++ b/src/cctag/geometry/Circle.hpp
@@ -24,9 +24,9 @@ public:
 
 	Circle() : Ellipse() {}
 
-	explicit Circle( const float r );
+	explicit Circle( float r );
 
-	Circle( const Point2d<Eigen::Vector3f>& center, const float r );
+	Circle( const Point2d<Eigen::Vector3f>& center, float r );
 
 	template <typename T>
 	Circle( const Point2d<T> & p1, const Point2d<T> & p2, const Point2d<T> & p3 )

--- a/src/cctag/geometry/Circle.hpp
+++ b/src/cctag/geometry/Circle.hpp
@@ -24,7 +24,7 @@ public:
 
 	Circle() : Ellipse() {}
 
-	Circle( const float r );
+	explicit Circle( const float r );
 
 	Circle( const Point2d<Eigen::Vector3f>& center, const float r );
 

--- a/src/cctag/geometry/Ellipse.cpp
+++ b/src/cctag/geometry/Ellipse.cpp
@@ -27,12 +27,12 @@ Ellipse::Ellipse( const Eigen::Matrix3f& matrix )
 	computeParameters();
 }
 
-Ellipse::Ellipse( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle )
+Ellipse::Ellipse( const Point2d<Eigen::Vector3f>& center, float a, float b, float angle )
 {
 	init( center, a, b, angle );
 }
 
-void Ellipse::init( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle )
+void Ellipse::init( const Point2d<Eigen::Vector3f>& center, float a, float b, float angle )
 {
 	if( a < 0.f || b < 0.f )
 	{
@@ -54,7 +54,7 @@ void Ellipse::setMatrix( const Eigen::Matrix3f& matrix )
 	computeParameters();
 }
 
-void Ellipse::setParameters( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle )
+void Ellipse::setParameters( const Point2d<Eigen::Vector3f>& center, float a, float b, float angle )
 {
 	if( a < 0.f || b < 0.f )
 	{
@@ -74,7 +74,7 @@ void Ellipse::setCenter( const Point2d<Eigen::Vector3f>& center )
 	computeMatrix();
 }
 
-void Ellipse::setA( const float a )
+void Ellipse::setA( float a )
 {
 	if( a < 0.f )
 	{
@@ -85,7 +85,7 @@ void Ellipse::setA( const float a )
 	computeMatrix();
 }
 
-void Ellipse::setB( const float b )
+void Ellipse::setB( float b )
 {
 	if( b < 0.f )
 	{
@@ -96,7 +96,7 @@ void Ellipse::setB( const float b )
 	computeMatrix();
 }
 
-void Ellipse::setAngle( const float angle )
+void Ellipse::setAngle( float angle )
 {
 	_angle = angle;
 	computeMatrix();
@@ -277,7 +277,7 @@ void getSortedOuterPoints(
         const Ellipse & ellipse,
         const std::vector< cctag::DirectedPoint2d<Eigen::Vector3f> > & points,
         std::vector< cctag::DirectedPoint2d<Eigen::Vector3f> > & resPoints,
-        const std::size_t requestedSize)
+        std::size_t requestedSize)
 {
   // map with the key = angle and the point index
   // Sort points in points by angle

--- a/src/cctag/geometry/Ellipse.hpp
+++ b/src/cctag/geometry/Ellipse.hpp
@@ -19,7 +19,7 @@ namespace geometry {
 class Ellipse
 {
 public:
-	typedef Eigen::Matrix3f Matrix;
+	using Matrix = Eigen::Matrix3f;
         
 	Ellipse()
                 : _matrix(Eigen::Matrix3f::Zero())

--- a/src/cctag/geometry/Ellipse.hpp
+++ b/src/cctag/geometry/Ellipse.hpp
@@ -30,7 +30,7 @@ public:
 	{
 	}
 
-	Ellipse( const Matrix& matrix );
+	explicit Ellipse( const Matrix& matrix );
 	Ellipse( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle );
 
 	inline const Matrix& matrix() const { return _matrix; }

--- a/src/cctag/geometry/Ellipse.hpp
+++ b/src/cctag/geometry/Ellipse.hpp
@@ -31,7 +31,7 @@ public:
 	}
 
 	explicit Ellipse( const Matrix& matrix );
-	Ellipse( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle );
+	Ellipse( const Point2d<Eigen::Vector3f>& center, float a, float b, float angle );
 
 	inline const Matrix& matrix() const { return _matrix; }
 	inline Matrix& matrix() { return _matrix; }
@@ -43,15 +43,15 @@ public:
 
 	void setMatrix( const Matrix& matrix );
 
-	void setParameters( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle );
+	void setParameters( const Point2d<Eigen::Vector3f>& center, float a, float b, float angle );
 
 	void setCenter( const Point2d<Eigen::Vector3f>& center );
 
-	void setA( const float a );
+	void setA( float a );
 
-	void setB( const float b );
+	void setB( float b );
 
-	void setAngle( const float angle );
+	void setAngle( float angle );
 
 	Ellipse transform(const Matrix& mT) const;
 
@@ -61,7 +61,7 @@ public:
         
         void getCanonicForm(Matrix& mCanonic, Matrix& mTprimal, Matrix& mTdual) const;
 
-	void init( const Point2d<Eigen::Vector3f>& center, const float a, const float b, const float angle );
+	void init( const Point2d<Eigen::Vector3f>& center, float a, float b, float angle );
 
 	friend  std::ostream& operator<<(std::ostream& os, const Ellipse& e);
 
@@ -77,7 +77,7 @@ void getSortedOuterPoints(
         const Ellipse & ellipse,
         const std::vector< cctag::DirectedPoint2d<Eigen::Vector3f> > & points,
         std::vector< cctag::DirectedPoint2d<Eigen::Vector3f> > & resPoints,
-        const std::size_t requestedSize);
+        std::size_t requestedSize);
 
 void scale(const Ellipse & ellipse, Ellipse & rescaleEllipse, float scale);
 

--- a/src/cctag/geometry/EllipseFromPoints.cpp
+++ b/src/cctag/geometry/EllipseFromPoints.cpp
@@ -123,9 +123,9 @@ void rasterizeEllipticalArc(const Ellipse & ellipse, const Point2d<Eigen::Vector
 			std::vector<float> intersections = intersectEllipseWithLine( ellipse, x, false );
 
 			if( intersections.size() == 2 ){
-				vPoint.push_back(Point2d<Eigen::Vector3i>(x,boost::math::round(intersections[intersectionIndex])));
+				vPoint.emplace_back(x,boost::math::round(intersections[intersectionIndex]));
 			}else if( intersections.size() == 1 ){
-				vPoint.push_back(Point2d<Eigen::Vector3i>(x,boost::math::round(intersections[0])));
+				vPoint.emplace_back(x,boost::math::round(intersections[0]));
 			}
 		}
 
@@ -138,9 +138,9 @@ void rasterizeEllipticalArc(const Ellipse & ellipse, const Point2d<Eigen::Vector
 			std::vector<float> intersections = intersectEllipseWithLine( ellipse, y, true );
 
 			if( intersections.size() == 2 ){
-				vPoint.push_back(Point2d<Eigen::Vector3i>(boost::math::round(intersections[intersectionIndex]),y));
+				vPoint.emplace_back(boost::math::round(intersections[intersectionIndex]), y);
 			}else if( intersections.size() == 1 ){
-				vPoint.push_back(Point2d<Eigen::Vector3i>(boost::math::round(intersections[0]),y));
+				vPoint.emplace_back(boost::math::round(intersections[0]), y);
 			}
 		}
 	}

--- a/src/cctag/geometry/EllipseFromPoints.cpp
+++ b/src/cctag/geometry/EllipseFromPoints.cpp
@@ -48,13 +48,13 @@ Point2d<Eigen::Vector3f> pointOnEllipse( const Ellipse & ellipse, const Point2d<
   return res;
 }
 
-void points( const Ellipse & ellipse, const std::size_t nb, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts )
+void points( const Ellipse & ellipse, std::size_t nb, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts )
 {
 	const float step = 2.0 * boost::math::constants::pi<float>() / nb;
 	points( ellipse, nb, step, 2 * boost::math::constants::pi<float>(), pts );
 }
 
-void points( const Ellipse & ellipse, const std::size_t nb, const float phi1, const float phi2, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts )
+void points( const Ellipse & ellipse, std::size_t nb, const float phi1, const float phi2, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts )
 {
 	const float step = 2.0 * boost::math::constants::pi<float>() / nb;
 	pts.reserve( std::size_t( ( phi2 - phi1 ) / step ) + 1 );
@@ -154,7 +154,7 @@ void rasterizeEllipticalArc(const Ellipse & ellipse, const Point2d<Eigen::Vector
  * Return intersection(s) values.
  */
 
-std::vector<float> intersectEllipseWithLine( const numerical::geometry::Ellipse& ellipse, const float y, bool horizontal)
+std::vector<float> intersectEllipseWithLine( const numerical::geometry::Ellipse& ellipse, float y, bool horizontal)
 {
 	using boost::math::pow;
 	std::vector<float> res;

--- a/src/cctag/geometry/EllipseFromPoints.hpp
+++ b/src/cctag/geometry/EllipseFromPoints.hpp
@@ -24,9 +24,9 @@ Point2d<Eigen::Vector3f> extractEllipsePointAtAngle( const Ellipse & ellipse, fl
 Point2d<Eigen::Vector3f> pointOnEllipse( const Ellipse & ellipse, const Point2d<Eigen::Vector3f> & p );
 
 ///@todo rename this function
-void points( const Ellipse & ellipse, const std::size_t nb, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts );
+void points( const Ellipse & ellipse, std::size_t nb, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts );
 ///@todo rename this function
-void points( const Ellipse & ellipse, const std::size_t nb, const float phi1, const float phi2, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts );
+void points( const Ellipse & ellipse, std::size_t nb, float phi1, float phi2, std::vector< cctag::Point2d<Eigen::Vector3f> > & pts );
 
 
 // Direct implementation of "NUMERICALLY STABLE DIRECT LEAST SQUARES FITTING OF ELLIPSES" by Halir, Flusser
@@ -60,7 +60,7 @@ std::size_t rasterizeEllipsePerimeter( const Ellipse & ellipse );
  * @param[in] y ordonate for which we compute intersection abscissa
  * @return intersected points sorted in ascend order (returns x coordinates: 0, 1, or 2 points).
  */
-std::vector<float> intersectEllipseWithLine( const numerical::geometry::Ellipse& ellipse, const float y, bool horizontal);
+std::vector<float> intersectEllipseWithLine( const numerical::geometry::Ellipse& ellipse, float y, bool horizontal);
 
 }
 }

--- a/src/cctag/geometry/Point.hpp
+++ b/src/cctag/geometry/Point.hpp
@@ -84,7 +84,7 @@ public:
           _grad(1) = dY;
         }
 
-	DirectedPoint2d( const Scalar px, const Scalar py, float dX, float dY)
+	DirectedPoint2d( const Scalar & px, const Scalar & py, float dX, float dY)
 		: Point2d<T>( px, py )
 	{
           _grad(0) = dX;

--- a/src/cctag/geometry/Point.hpp
+++ b/src/cctag/geometry/Point.hpp
@@ -64,8 +64,8 @@ template<class T>
 class DirectedPoint2d : public Point2d<T>
 {
         using Scalar = typename Point2d<T>::Scalar;
-	typedef Point2d<T> Parent;
-	typedef DirectedPoint2d<T> This;
+	using Parent = Point2d<T>;
+	using This = DirectedPoint2d<T>;
         
         Eigen::Vector2f _grad;
 

--- a/src/cctag/utils/Backtrace.cpp
+++ b/src/cctag/utils/Backtrace.cpp
@@ -79,14 +79,14 @@ namespace boost {
             std::ostringstream res;
             res.imbue(std::locale::classic());
             res << ptr<<": ";
-            Dl_info info = {0};
+            Dl_info info = {nullptr};
             if(dladdr(ptr,&info) == 0) {
                 res << "???";
             }
             else {
                 if(info.dli_sname) {
                     int status = 0;
-                    char *demangled = abi::__cxa_demangle(info.dli_sname,0,0,&status);
+                    char *demangled = abi::__cxa_demangle(info.dli_sname,nullptr,nullptr,&status);
                     if(demangled) {
                         res << demangled;
                         free(demangled);

--- a/src/cctag/utils/Backtrace.cpp
+++ b/src/cctag/utils/Backtrace.cpp
@@ -47,9 +47,9 @@ namespace boost {
     namespace stack_trace {
         #if defined(BOOST_HAVE_EXECINFO)
         
-        int trace(void **array,int n)
+        int trace(void **addresses, int size)
         {
-            return :: backtrace(array,n);
+            return :: backtrace(addresses, size);
         }
         
         #elif defined(BOOST_MSVC)
@@ -72,15 +72,15 @@ namespace boost {
         
         #if defined(BOOST_HAVE_DLADDR) && defined(BOOST_HAVE_ABI_CXA_DEMANGLE)
         
-        std::string get_symbol(void *ptr)
+        std::string get_symbol(void *address)
         {
-            if(!ptr)
+            if(!address)
                 return std::string();
             std::ostringstream res;
             res.imbue(std::locale::classic());
-            res << ptr<<": ";
+            res << address<<": ";
             Dl_info info = {nullptr};
-            if(dladdr(ptr,&info) == 0) {
+            if(dladdr(address,&info) == 0) {
                 res << "???";
             }
             else {
@@ -99,7 +99,7 @@ namespace boost {
                     res << "???";
                 }
 
-                unsigned offset = (char *)ptr - (char *)info.dli_saddr;
+                unsigned offset = (char *)address - (char *)info.dli_saddr;
                 res << std::hex <<" + 0x" << offset ;
 
                 if(info.dli_fname)

--- a/src/cctag/utils/Backtrace.cpp
+++ b/src/cctag/utils/Backtrace.cpp
@@ -29,8 +29,8 @@
 #ifdef BOOST_HAVE_DLADDR
 #include <dlfcn.h>
 #endif
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 #include <ostream>
 #include <sstream>
 #include <iomanip>

--- a/src/cctag/utils/Backtrace.hpp
+++ b/src/cctag/utils/Backtrace.hpp
@@ -20,10 +20,10 @@
 namespace boost {
 
     namespace stack_trace {
-        int trace(void **addresses,int size);
+        int trace(void **addresses, int size);
         void write_symbols(void *const *addresses,int size,std::ostream &);
         std::string get_symbol(void *address);
-        std::string get_symbols(void * const *address,int size);
+        std::string get_symbols(void * const *addresses,int size);
     } // stack_trace
 
     class backtrace {

--- a/src/cctag/utils/Backtrace.hpp
+++ b/src/cctag/utils/Backtrace.hpp
@@ -40,9 +40,7 @@ namespace boost {
             frames_.resize(size);
         }
 
-        virtual ~backtrace() throw()
-        {
-        }
+        virtual ~backtrace() throw() = default;
 
         size_t stack_size() const
         {

--- a/src/cctag/utils/Backtrace.hpp
+++ b/src/cctag/utils/Backtrace.hpp
@@ -31,7 +31,7 @@ namespace boost {
         
         static size_t const default_stack_size = 32;
 
-        backtrace(size_t frames_no = default_stack_size) 
+        explicit backtrace(size_t frames_no = default_stack_size)
         {
             if(frames_no == 0)
                 return;
@@ -160,7 +160,7 @@ namespace boost {
     namespace details {
         class trace_manip {
         public:
-            trace_manip(backtrace const *tr) :
+            explicit trace_manip(backtrace const *tr) :
                 tr_(tr)
             {
             }

--- a/src/cctag/utils/Backtrace.hpp
+++ b/src/cctag/utils/Backtrace.hpp
@@ -35,7 +35,7 @@ namespace boost {
         {
             if(frames_no == 0)
                 return;
-            frames_.resize(frames_no,0);
+            frames_.resize(frames_no, nullptr);
             int size = stack_trace::trace(&frames_.front(),frames_no);
             frames_.resize(size);
         }
@@ -53,7 +53,7 @@ namespace boost {
         {
             if(frame_no < stack_size())
                 return frames_[frame_no];
-            return 0;
+            return nullptr;
         }
 
         void trace_line(unsigned frame_no,std::ostream &out) const

--- a/src/cctag/utils/Exceptions.hpp
+++ b/src/cctag/utils/Exceptions.hpp
@@ -68,7 +68,7 @@ public:
 	}
 
 	template<typename V>
-	error_info( const V& value )
+	explicit error_info( const V& value )
 	{
 		_value._v << value;
 	}
@@ -303,7 +303,7 @@ struct File : virtual public Value
 {
 	File()
 	{}
-	File( const std::string& path )
+	explicit File( const std::string& path )
 	{
 		*this << filename(path);
 	}
@@ -316,7 +316,7 @@ struct FileNotExist : virtual public File
 {
 	FileNotExist()
 	{}
-	FileNotExist( const std::string& path )
+	explicit FileNotExist( const std::string& path )
 	: File( path )
 	{}
 };
@@ -328,7 +328,7 @@ struct NoDirectory : virtual public File
 {
 	NoDirectory()
 	{}
-	NoDirectory( const std::string& path )
+	explicit NoDirectory( const std::string& path )
 	: File( path )
 	{}
 };
@@ -340,7 +340,7 @@ struct ReadOnlyFile : virtual public File
 {
 	ReadOnlyFile()
 	{}
-	ReadOnlyFile( const std::string& path )
+	explicit ReadOnlyFile( const std::string& path )
 	: File( path )
 	{}
 };

--- a/src/cctag/utils/Exceptions.hpp
+++ b/src/cctag/utils/Exceptions.hpp
@@ -72,7 +72,7 @@ public:
 		_value._v << value;
 	}
 
-	~error_info() throw( ) {}
+	~error_info() throw( ) override  {}
 
 	template<typename V>
 	This& operator+( const V& v )
@@ -87,7 +87,7 @@ public:
 private:
 	
 	#if( BOOST_VERSION >= 105400 )
-	inline std::string name_value_string() const
+	inline std::string name_value_string() const override
 	{
 		return to_string_stub(*this);
 	}

--- a/src/cctag/utils/Exceptions.hpp
+++ b/src/cctag/utils/Exceptions.hpp
@@ -37,7 +37,7 @@ namespace boost {
 
 struct error_info_sstream
 {
-	typedef std::ostringstream value_type;
+	using value_type = std::ostringstream;
 	value_type _v;
 };
 
@@ -56,9 +56,9 @@ template<class Tag>
 class error_info<Tag, error_info_sstream>: public exception_detail::error_info_base
 {
 public:
-	typedef error_info_sstream T;
-	typedef error_info<Tag, T> This;
-	typedef T value_type;
+	using T = boost::error_info_sstream;
+	using This = error_info<Tag, T>;
+	using value_type = T;
 
 	error_info() {}
 	error_info( const This& v )
@@ -205,7 +205,7 @@ typedef ::boost::error_info<struct tag_frame, long int> frame;
  * @brief Problem with a file.
  * @remark User information.
  */
-typedef ::boost::errinfo_file_name filename;
+using filename = ::boost::errinfo_file_name;
 /// @}
 #endif
 

--- a/src/cctag/utils/Exceptions.hpp
+++ b/src/cctag/utils/Exceptions.hpp
@@ -60,7 +60,8 @@ public:
 	using This = error_info<Tag, T>;
 	using value_type = T;
 
-	error_info() {}
+	error_info() = default;
+
 	error_info( const This& v )
 	{
 		_value._v << v._value._v.str();
@@ -72,7 +73,7 @@ public:
 		_value._v << value;
 	}
 
-	~error_info() throw( ) override  {}
+	virtual ~error_info() throw( )  = default;
 
 	template<typename V>
 	This& operator+( const V& v )

--- a/src/cctag/utils/FileDebug.cpp
+++ b/src/cctag/utils/FileDebug.cpp
@@ -17,7 +17,7 @@ namespace cctag
 {
 
 CCTagFileDebug::CCTagFileDebug()
-: _sstream(NULL) {
+: _sstream(nullptr) {
 
 }
 

--- a/src/cctag/utils/FileDebug.cpp
+++ b/src/cctag/utils/FileDebug.cpp
@@ -54,7 +54,7 @@ void CCTagFileDebug::outputFlowComponentAssemblingInfos(int status)
 #if defined CCTAG_SERIALIZE && defined DEBUG
     boost::archive::text_oarchive oa(*_sstream);
 
-    BOOST_FOREACH(const int index, _vflowComponentIndex) {
+    for(const int index : _vflowComponentIndex) {
         oa & BOOST_SERIALIZATION_NVP(index);
     }
     oa & BOOST_SERIALIZATION_NVP(status);
@@ -68,7 +68,7 @@ void CCTagFileDebug::outputFlowComponentAssemblingInfos(int status)
 void CCTagFileDebug::printInfos()
 {
     CCTAG_COUT("Print infos");
-    BOOST_FOREACH(const int index, _vflowComponentIndex) {
+    for(const int index : _vflowComponentIndex) {
         CCTAG_COUT_VAR(index);
     }
     CCTAG_COUT_VAR(_isAssembled);

--- a/src/cctag/utils/FileDebug.cpp
+++ b/src/cctag/utils/FileDebug.cpp
@@ -103,7 +103,7 @@ void CCTagFileDebug::incrementFlowComponentIndex(int n)
 #endif            
 }
 
-void CCTagFileDebug::setResearchArea(cctag::numerical::geometry::Ellipse circularResearchArea)
+void CCTagFileDebug::setResearchArea(const cctag::numerical::geometry::Ellipse& circularResearchArea)
 {
 #if defined CCTAG_SERIALIZE && defined DEBUG
     _researchArea = circularResearchArea;

--- a/src/cctag/utils/FileDebug.cpp
+++ b/src/cctag/utils/FileDebug.cpp
@@ -21,10 +21,7 @@ CCTagFileDebug::CCTagFileDebug()
 
 }
 
-CCTagFileDebug::~CCTagFileDebug()
-{
-
-}
+CCTagFileDebug::~CCTagFileDebug() = default;
 
 void CCTagFileDebug::setPath(const std::string& folderName)
 {

--- a/src/cctag/utils/FileDebug.hpp
+++ b/src/cctag/utils/FileDebug.hpp
@@ -51,7 +51,7 @@ namespace cctag {
             void initFlowComponentsIndex(int size);
             void resetFlowComponent();
             void incrementFlowComponentIndex(int n);
-            void setResearchArea(cctag::numerical::geometry::Ellipse circularResearchArea);
+            void setResearchArea(const cctag::numerical::geometry::Ellipse& circularResearchArea);
             void setFlowComponentAssemblingState( bool isAssembled, int indexSelectedFlowComponent);
             void outputFlowComponentInfos(const cctag::CCTagFlowComponent & flowComponent);
             

--- a/src/cctag/utils/LogTime.cpp
+++ b/src/cctag/utils/LogTime.cpp
@@ -12,7 +12,7 @@ namespace logtime {
 
 bool Mgmt::Measurement::doPrint( ) const
 {
-    return ( _probe != 0 );
+    return ( _probe != nullptr );
 }
 
 void Mgmt::Measurement::print( std::ostream& ostr ) const

--- a/src/cctag/utils/LogTime.hpp
+++ b/src/cctag/utils/LogTime.hpp
@@ -51,7 +51,7 @@ struct Mgmt
     int                      _reserved;
     int                      _idx;
 
-    Mgmt( int rsvp );
+    explicit Mgmt( int rsvp );
 
     void resetStartTime( );
 

--- a/src/cctag/utils/LogTime.hpp
+++ b/src/cctag/utils/LogTime.hpp
@@ -27,7 +27,7 @@ struct Mgmt
     {
     public:
         Measurement( )
-            : _probe( 0 )
+            : _probe( nullptr )
         { }
 
         void log( const char* probename, const btime::time_duration& duration ) {

--- a/src/cctag/utils/Singleton.hpp
+++ b/src/cctag/utils/Singleton.hpp
@@ -56,7 +56,7 @@ public:
 };
 
 template <class T>
-T * Singleton<T>::inst = NULL;
+T * Singleton<T>::inst = nullptr;
 
 template <class T>Singleton<T>::~Singleton() {}
 

--- a/src/cctag/utils/Singleton.hpp
+++ b/src/cctag/utils/Singleton.hpp
@@ -26,10 +26,10 @@ class Singleton
 private:
 	static T* inst;
 
-	Singleton( const Singleton& ) {}
+	Singleton( const Singleton& ) = default;
 	Singleton & operator=( const Singleton& ) {}
 
-protected: Singleton() {}
+protected: Singleton() = default;
 	virtual ~Singleton() = 0;
 
 public:
@@ -50,7 +50,7 @@ public:
 	static void destroy()
 	{
 		delete inst;
-		inst = NULL;
+		inst = nullptr;
 	}
 
 };
@@ -58,16 +58,15 @@ public:
 template <class T>
 T * Singleton<T>::inst = nullptr;
 
-template <class T>Singleton<T>::~Singleton() {}
+template <class T>Singleton<T>::~Singleton() = default;
 
 ///macro to implement singleton. Use it in derived class declaration
 #define MAKE_SINGLETON( Class ) \
 	public: \
 		friend class Singleton < Class >; \
 	private: \
-		Class() { \
-		} \
-		~Class() {}
+		Class() = default; \
+		~Class() = default;
 
 ///macro to implement singleton. Use it in derived class declaration
 #define MAKE_SINGLETON_WITHCONSTRUCTORS( Class ) \

--- a/src/cctag/utils/VisualDebug.cpp
+++ b/src/cctag/utils/VisualDebug.cpp
@@ -180,7 +180,7 @@ void CCTagVisualDebug::drawPoint(const cctag::DirectedPoint2d<Eigen::Vector3f> &
 void CCTagVisualDebug::drawPoints(const std::vector<cctag::Point2d<Eigen::Vector3f> > & points, const cctag::Color & color)
 {
 #ifdef CCTAG_SERIALIZE
-  BOOST_FOREACH(const cctag::Point2d<Eigen::Vector3f> & point, points) {
+  for(const cctag::Point2d<Eigen::Vector3f> & point : points) {
       CCTagVisualDebug::instance().drawPoint(point, cctag::color_red);
   }
 #endif
@@ -190,7 +190,7 @@ void CCTagVisualDebug::drawPoints(const std::vector<cctag::Point2d<Eigen::Vector
 void CCTagVisualDebug::drawPoints(const std::vector<cctag::DirectedPoint2d<Eigen::Vector3f> > & points, const cctag::Color & color)
 {
 #ifdef CCTAG_SERIALIZE
-  BOOST_FOREACH(const cctag::Point2d<Eigen::Vector3f> & point, points) {
+  for(const cctag::Point2d<Eigen::Vector3f> & point : points) {
       CCTagVisualDebug::instance().drawPoint(cctag::Point2d<Eigen::Vector3f>(point.x(),point.y()), cctag::color_red);
   }
 #endif
@@ -283,7 +283,7 @@ void CCTagVisualDebug::out(const std::string & filename) const {
 
 void CCTagVisualDebug::outPutAllSessions() const {
 #if defined(CCTAG_SERIALIZE) && defined(VISUAL_DEBUG)
-    BOOST_FOREACH(const Sessions::const_iterator::value_type & v, _sessions) {
+    for(const Sessions::const_iterator::value_type & v : _sessions) {
         const std::string filename = _path + "/" + v.first + ".png";
         cv::imwrite(filename, v.second);
     }
@@ -296,7 +296,7 @@ void CCTagVisualDebug::writeLocalizationView(cctag::CCTag::List& markers) const 
     localizationResultFileName << "../localization/" << _imageFileName;
     CCTagVisualDebug::instance().newSession(localizationResultFileName.str());
 
-    BOOST_FOREACH(const cctag::CCTag & marker, markers) {
+    for(const cctag::CCTag & marker : markers) {
         CCTagVisualDebug::instance().drawMarker(marker);
         CCTagVisualDebug::instance().drawInfos(marker);
     }
@@ -310,7 +310,7 @@ void CCTagVisualDebug::writeIdentificationView(cctag::CCTag::List& markers) cons
     identificationResultFileName << "../identification/" << _imageFileName;
     CCTagVisualDebug::instance().newSession(identificationResultFileName.str());
 
-    BOOST_FOREACH(const cctag::CCTag & marker, markers) {
+    for(const cctag::CCTag & marker : markers) {
         CCTagVisualDebug::instance().drawMarker(marker);
         CCTagVisualDebug::instance().drawPoints(marker.rescaledOuterEllipsePoints(), cctag::color_red);
         CCTagVisualDebug::instance().drawInfos(marker);

--- a/src/cctag/utils/VisualDebug.cpp
+++ b/src/cctag/utils/VisualDebug.cpp
@@ -16,13 +16,9 @@ namespace bfs = boost::filesystem;
 namespace cctag
 {
 
-CCTagVisualDebug::CCTagVisualDebug()
-{
-}
+CCTagVisualDebug::CCTagVisualDebug() = default;
 
-CCTagVisualDebug::~CCTagVisualDebug()
-{
-}
+CCTagVisualDebug::~CCTagVisualDebug() = default;
 
 void CCTagVisualDebug::initializeFolders(const boost::filesystem::path & rootPath, const std::string & outputFolder, std::size_t nCrowns)
 {

--- a/src/cctag/utils/VisualDebug.hpp
+++ b/src/cctag/utils/VisualDebug.hpp
@@ -42,16 +42,16 @@ public:
 
     void initBackgroundImage(const cv::Mat & back);
     
-    void initializeFolders(const boost::filesystem::path & filename, const std::string & outputFolder, std::size_t nCrowns = 4);
+    void initializeFolders(const boost::filesystem::path & rootPath, const std::string & outputFolder, std::size_t nCrowns = 4);
 
     void newSession(const std::string & sessionName);
 
     void drawText(const cctag::Point2d<Eigen::Vector3f> & p, const std::string & text, const cctag::Color & color);
 
-    void drawPoint(const cctag::Point2d<Eigen::Vector3f> & p, const cctag::Color & color);
+    void drawPoint(const cctag::Point2d<Eigen::Vector3f> & point, const cctag::Color & color);
     void drawPoint(const cctag::DirectedPoint2d<Eigen::Vector3f> & point, const cctag::Color & color);
 
-    void drawPoints(const std::vector<cctag::Point2d<Eigen::Vector3f> > & pts, const cctag::Color & color);
+    void drawPoints(const std::vector<cctag::Point2d<Eigen::Vector3f> > & points, const cctag::Color & color);
     
     void drawPoints(const std::vector<cctag::DirectedPoint2d<Eigen::Vector3f> > & points, const cctag::Color & color);
 

--- a/src/cctag/utils/pcg_extras.hpp
+++ b/src/cctag/utils/pcg_extras.hpp
@@ -220,7 +220,7 @@ operator<<(std::basic_ostream<CharT,Traits>&out, uint8_t value)
 
 template <typename CharT, typename Traits>
 std::basic_istream<CharT,Traits>&
-operator>>(std::basic_istream<CharT,Traits>& in, uint8_t target)
+operator>>(std::basic_istream<CharT,Traits>& in, uint8_t& target)
 {
     uint32_t value = 0xdecea5edU;
     in >> value;

--- a/src/cctag/utils/pcg_extras.hpp
+++ b/src/cctag/utils/pcg_extras.hpp
@@ -79,7 +79,7 @@
  */
 #if __SIZEOF_INT128__
     namespace pcg_extras {
-        typedef __uint128_t pcg128_t;
+        using pcg128_t = __uint128_t;
     }
     #define PCG_128BIT_CONSTANT(high,low) \
             ((pcg128_t(high) << 64) + low)
@@ -105,7 +105,7 @@ namespace pcg_extras {
  */
 
 #ifndef PCG_BITCOUNT_T
-    typedef uint8_t bitcount_t;
+    using bitcount_t = uint8_t;
 #else
     typedef PCG_BITCOUNT_T bitcount_t;
 #endif
@@ -384,8 +384,8 @@ SrcIter uneven_copy_impl(
     SrcIter src_first, DestIter dest_first, DestIter dest_last,
     std::true_type)
 {
-    typedef typename std::iterator_traits<SrcIter>::value_type  src_t;
-    typedef typename std::iterator_traits<DestIter>::value_type dest_t;
+    using src_t = typename std::iterator_traits<SrcIter>::value_type;
+    using dest_t = typename std::iterator_traits<DestIter>::value_type;
 
     constexpr bitcount_t SRC_SIZE  = sizeof(src_t);
     constexpr bitcount_t DEST_SIZE = sizeof(dest_t);
@@ -413,8 +413,8 @@ SrcIter uneven_copy_impl(
     SrcIter src_first, DestIter dest_first, DestIter dest_last,
     std::false_type)
 {
-    typedef typename std::iterator_traits<SrcIter>::value_type  src_t;
-    typedef typename std::iterator_traits<DestIter>::value_type dest_t;
+    using src_t = typename std::iterator_traits<SrcIter>::value_type;
+    using dest_t = typename std::iterator_traits<DestIter>::value_type;
 
     constexpr auto SRC_SIZE  = sizeof(src_t);
     constexpr auto SRC_BITS  = SRC_SIZE * 8;
@@ -441,8 +441,8 @@ template<class SrcIter, class DestIter>
 inline SrcIter uneven_copy(SrcIter src_first,
                            DestIter dest_first, DestIter dest_last)
 {
-    typedef typename std::iterator_traits<SrcIter>::value_type  src_t;
-    typedef typename std::iterator_traits<DestIter>::value_type dest_t;
+    using src_t = typename std::iterator_traits<SrcIter>::value_type;
+    using dest_t = typename std::iterator_traits<DestIter>::value_type;
 
     constexpr bool DEST_IS_SMALLER = sizeof(dest_t) < sizeof(src_t);
 
@@ -465,7 +465,7 @@ template <size_t size, typename SeedSeq, typename DestIter>
 void generate_to_impl(SeedSeq&& generator, DestIter dest,
                       std::false_type)
 {
-    typedef typename std::iterator_traits<DestIter>::value_type dest_t;
+    using dest_t = typename std::iterator_traits<DestIter>::value_type;
     constexpr auto DEST_SIZE = sizeof(dest_t);
     constexpr auto GEN_SIZE  = sizeof(uint32_t);
 
@@ -493,7 +493,7 @@ void generate_to_impl(SeedSeq&& generator, DestIter dest,
 template <size_t size, typename SeedSeq, typename DestIter>
 inline void generate_to(SeedSeq&& generator, DestIter dest)
 {
-    typedef typename std::iterator_traits<DestIter>::value_type dest_t;
+    using dest_t = typename std::iterator_traits<DestIter>::value_type;
     constexpr bool IS_32BIT = sizeof(dest_t) == sizeof(uint32_t);
 
     generate_to_impl<size>(std::forward<SeedSeq>(generator), dest,
@@ -517,7 +517,7 @@ template <typename RngType>
 auto bounded_rand(RngType& rng, typename RngType::result_type upper_bound)
         -> typename RngType::result_type
 {
-    typedef typename RngType::result_type rtype;
+    using rtype = typename RngType::result_type;
     rtype threshold = (RngType::max() - RngType::min() + rtype(1) - upper_bound)
                     % upper_bound;
     for (;;) {
@@ -530,7 +530,7 @@ auto bounded_rand(RngType& rng, typename RngType::result_type upper_bound)
 template <typename Iter, typename RandType>
 void shuffle(Iter from, Iter to, RandType&& rng)
 {
-    typedef typename std::iterator_traits<Iter>::difference_type delta_t;
+    using delta_t = typename std::iterator_traits<Iter>::difference_type;
     auto count = to - from;
     while (count > 1) {
         delta_t chosen(bounded_rand(rng, count));
@@ -558,7 +558,7 @@ class seed_seq_from {
 private:
     RngType rng_;
 
-    typedef uint_least32_t result_type;
+    using result_type = uint_least32_t;
 
 public:
     template<typename... Args>

--- a/src/cctag/utils/pcg_extras.hpp
+++ b/src/cctag/utils/pcg_extras.hpp
@@ -621,7 +621,7 @@ std::ostream& operator<<(std::ostream& out, printable_typename<T>) {
 #ifdef __GNUC__
     int status;
     const char* pretty_name =
-        abi::__cxa_demangle(implementation_typename, NULL, NULL, &status);
+        abi::__cxa_demangle(implementation_typename, nullptr, nullptr, &status);
     if (status == 0)
         out << pretty_name;
     free((void*) pretty_name);

--- a/src/cctag/utils/pcg_extras.hpp
+++ b/src/cctag/utils/pcg_extras.hpp
@@ -562,7 +562,7 @@ private:
 
 public:
     template<typename... Args>
-    seed_seq_from(Args&&... args) :
+    explicit seed_seq_from(Args&&... args) :
         rng_(std::forward<Args>(args)...)
     {
         // Nothing (else) to do...

--- a/src/cctag/utils/pcg_random.hpp
+++ b/src/cctag/utils/pcg_random.hpp
@@ -455,7 +455,7 @@ public:
         }
     }
 
-    engine(itype state = itype(0xcafef00dd15ea5e5ULL))
+    explicit engine(itype state = itype(0xcafef00dd15ea5e5ULL))
         : state_(this->is_mcg ? state|state_type(3U)
                               : bump(state + this->increment()))
     {
@@ -1229,7 +1229,7 @@ public:
         advance(distance, false);
     }
 
-    extended(const result_type* data)
+    explicit extended(const result_type* data)
         : baseclass()
     {
         datainit(data);
@@ -1258,7 +1258,7 @@ public:
         selfinit();
     }
 
-    extended(state_type seed)
+    explicit extended(state_type seed)
         : baseclass(seed)
     {
         selfinit();
@@ -1283,7 +1283,7 @@ public:
     template<typename SeedSeq, typename = typename std::enable_if<
            !std::is_convertible<SeedSeq, result_type>::value
         && !std::is_convertible<SeedSeq, extended>::value>::type>
-    extended(SeedSeq&& seedSeq)
+    explicit extended(SeedSeq&& seedSeq)
         : baseclass(seedSeq)
     {
         generate_to<table_size>(seedSeq, data_);

--- a/src/cctag/utils/pcg_random.hpp
+++ b/src/cctag/utils/pcg_random.hpp
@@ -188,7 +188,7 @@ protected:
     }
 
 public:
-    typedef itype state_type;
+    using state_type = itype;
 
     constexpr itype increment() const {
         return itype(reinterpret_cast<unsigned long>(this) | 1);
@@ -228,7 +228,7 @@ protected:
     }
 
 public:
-    typedef itype state_type;
+    using state_type = itype;
 
     static constexpr itype increment() {
         return 0;
@@ -262,7 +262,7 @@ protected:
     }
 
 public:
-    typedef itype state_type;
+    using state_type = itype;
 
     static constexpr itype stream()
     {
@@ -293,8 +293,8 @@ protected:
     itype inc_ = default_increment<itype>::increment();
 
 public:
-    typedef itype state_type;
-    typedef itype stream_state;
+    using state_type = itype;
+    using stream_state = itype;
 
     constexpr itype increment() const {
         return inc_;
@@ -362,8 +362,8 @@ protected:
     using multiplier_mixin::multiplier;
 
 public:
-    typedef xtype result_type;
-    typedef itype state_type;
+    using result_type = xtype;
+    using state_type = itype;
 
     static constexpr size_t period_pow2()
     {
@@ -1006,14 +1006,14 @@ struct xsl_rr_mixin {
  */
 
 template <typename T> struct halfsize_trait {};
-template <> struct halfsize_trait<pcg128_t>  { typedef uint64_t type; };
-template <> struct halfsize_trait<uint64_t>  { typedef uint32_t type; };
-template <> struct halfsize_trait<uint32_t>  { typedef uint16_t type; };
-template <> struct halfsize_trait<uint16_t>  { typedef uint8_t type;  };
+template <> struct halfsize_trait<pcg128_t>  { using type = uint64_t; };
+template <> struct halfsize_trait<uint64_t>  { using type = uint32_t; };
+template <> struct halfsize_trait<uint32_t>  { using type = uint16_t; };
+template <> struct halfsize_trait<uint16_t>  { using type = uint8_t;  };
 
 template <typename xtype, typename itype>
 struct xsl_rr_rr_mixin {
-    typedef typename halfsize_trait<itype>::type htype;
+    using htype = typename halfsize_trait<itype>::type;
 
     static itype output(itype internal)
     {
@@ -1100,8 +1100,8 @@ template <typename baseclass>
 struct inside_out : private baseclass {
     inside_out() = delete;
 
-    typedef typename baseclass::result_type result_type;
-    typedef typename baseclass::state_type  state_type;
+    using result_type = typename baseclass::result_type;
+    using state_type = typename baseclass::state_type;
     static_assert(sizeof(result_type) == sizeof(state_type),
                   "Require a RNG whose output function is a permutation");
 
@@ -1141,9 +1141,9 @@ struct inside_out : private baseclass {
 template <bitcount_t table_pow2, bitcount_t advance_pow2, typename baseclass, typename extvalclass, bool kdd = true>
 class extended : public baseclass {
 public:
-    typedef typename baseclass::state_type  state_type;
-    typedef typename baseclass::result_type result_type;
-    typedef inside_out<extvalclass> insideout;
+    using state_type = typename baseclass::state_type;
+    using result_type = typename baseclass::result_type;
+    using insideout = inside_out<extvalclass>;
 
 private:
     static constexpr bitcount_t rtypebits = sizeof(result_type)*8;
@@ -1450,8 +1450,8 @@ void
 extended<table_pow2,advance_pow2,baseclass,extvalclass,kdd>::advance_table(
         state_type delta, bool isForwards)
 {
-    typedef typename baseclass::state_type   base_state_t;
-    typedef typename extvalclass::state_type ext_state_t;
+    using base_state_t = typename baseclass::state_type;
+    using ext_state_t = typename extvalclass::state_type;
     constexpr bitcount_t basebits = sizeof(base_state_t)*8;
     constexpr bitcount_t extbits  = sizeof(ext_state_t)*8;
     static_assert(basebits <= extbits || advance_pow2 > 0,
@@ -1667,27 +1667,27 @@ using ext_setseq_xsl_rr_128_64 =
 
 } // namespace pcg_engines
 
-typedef pcg_engines::setseq_xsh_rr_64_32        pcg32;
-typedef pcg_engines::oneseq_xsh_rr_64_32        pcg32_oneseq;
-typedef pcg_engines::unique_xsh_rr_64_32        pcg32_unique;
-typedef pcg_engines::mcg_xsh_rs_64_32           pcg32_fast;
+using pcg32 = pcg_engines::setseq_xsh_rr_64_32;
+using pcg32_oneseq = pcg_engines::oneseq_xsh_rr_64_32;
+using pcg32_unique = pcg_engines::unique_xsh_rr_64_32;
+using pcg32_fast = pcg_engines::mcg_xsh_rs_64_32;
 
-typedef pcg_engines::setseq_xsl_rr_128_64       pcg64;
-typedef pcg_engines::oneseq_xsl_rr_128_64       pcg64_oneseq;
-typedef pcg_engines::unique_xsl_rr_128_64       pcg64_unique;
-typedef pcg_engines::mcg_xsl_rr_128_64          pcg64_fast;
+using pcg64 = pcg_engines::setseq_xsl_rr_128_64;
+using pcg64_oneseq = pcg_engines::oneseq_xsl_rr_128_64;
+using pcg64_unique = pcg_engines::unique_xsl_rr_128_64;
+using pcg64_fast = pcg_engines::mcg_xsl_rr_128_64;
 
-typedef pcg_engines::setseq_rxs_m_xs_8_8        pcg8_once_insecure;
-typedef pcg_engines::setseq_rxs_m_xs_16_16      pcg16_once_insecure;
-typedef pcg_engines::setseq_rxs_m_xs_32_32      pcg32_once_insecure;
-typedef pcg_engines::setseq_rxs_m_xs_64_64      pcg64_once_insecure;
-typedef pcg_engines::setseq_xsl_rr_rr_128_128   pcg128_once_insecure;
+using pcg8_once_insecure = pcg_engines::setseq_rxs_m_xs_8_8;
+using pcg16_once_insecure = pcg_engines::setseq_rxs_m_xs_16_16;
+using pcg32_once_insecure = pcg_engines::setseq_rxs_m_xs_32_32;
+using pcg64_once_insecure = pcg_engines::setseq_rxs_m_xs_64_64;
+using pcg128_once_insecure = pcg_engines::setseq_xsl_rr_rr_128_128;
 
-typedef pcg_engines::oneseq_rxs_m_xs_8_8        pcg8_oneseq_once_insecure;
-typedef pcg_engines::oneseq_rxs_m_xs_16_16      pcg16_oneseq_once_insecure;
-typedef pcg_engines::oneseq_rxs_m_xs_32_32      pcg32_oneseq_once_insecure;
-typedef pcg_engines::oneseq_rxs_m_xs_64_64      pcg64_oneseq_once_insecure;
-typedef pcg_engines::oneseq_xsl_rr_rr_128_128   pcg128_oneseq_once_insecure;
+using pcg8_oneseq_once_insecure = pcg_engines::oneseq_rxs_m_xs_8_8;
+using pcg16_oneseq_once_insecure = pcg_engines::oneseq_rxs_m_xs_16_16;
+using pcg32_oneseq_once_insecure = pcg_engines::oneseq_rxs_m_xs_32_32;
+using pcg64_oneseq_once_insecure = pcg_engines::oneseq_rxs_m_xs_64_64;
+using pcg128_oneseq_once_insecure = pcg_engines::oneseq_xsl_rr_rr_128_128;
 
 
 // These two extended RNGs provide two-dimensionally equidistributed

--- a/src/cctag/utils/pcg_random.hpp
+++ b/src/cctag/utils/pcg_random.hpp
@@ -320,7 +320,7 @@ public:
 protected:
     specific_stream() = default;
 
-    specific_stream(itype specific_seq)
+    explicit specific_stream(itype specific_seq)
         : inc_((specific_seq << 1) | itype(1U))
     {
         // Nothing (else) to do.

--- a/src/cctag/utils/pcg_uint128.hpp
+++ b/src/cctag/utils/pcg_uint128.hpp
@@ -257,7 +257,7 @@ public:
              typename std::enable_if<(std::is_integral<Integral>::value
                                       && sizeof(Integral) <= sizeof(UIntX2))
                                     >::type* = nullptr>
-    constexpr uint_x4(Integral v01)
+    explicit constexpr uint_x4(Integral v01)
 #if PCG_LITTLE_ENDIAN
        : d{UIntX2(v01),0UL}
 #else


### PR DESCRIPTION
This PR is an attempt to modernize the code towards C++11. It is mostly the result of applying `clang-tidy` to the code, with some supervision :-)
 
Main rules applied
* removed BOOST_FOREACH and other old style `for` in favour of c++11 range for a
* using `nullptr`, `using` instead of typedef
* `override`, `default` and `explicit` where necessary
* using `<clibrary>` instead of deprecated `<library.h>`
* reducing the scope of some variable and default init for class member not initialized by the constructor(s)

Incidentally it fixes some potential bugs:
* the order of parameters in `cctagDetection()` was inverted between the .hpp and the .cpp (!)
* there was a missing `find_dependency(OpenCV)` in the CCTag_config.cmake which prevented the use of the library as a 3rd party unless the hosting project had a direct dependency on OpenCV (which actually should be always the case since cctagDetection() uses opencv in its API)
* a bug in `pcg_extra` prevented the reading of integer from stream because of a missing reference in the params

Finally, it adds ccache to try to speed up the compilation on travis, but the bottleneck remains the nvcc cuda part (we should maybe limit the number of code architectures to generate just for travis?).

NOTA BENE: There is still a lot of formatting issues (tabs, inconsistent indenting etc...) so i just fixed in some places where it was needed for these changes, another PR will take of care of that.