### PR TITLE
fix remaining typedef

### DIFF
--- a/src/cctag/utils/pcg_extras.hpp
+++ b/src/cctag/utils/pcg_extras.hpp
@@ -86,7 +86,7 @@
 #else
     #include "pcg_uint128.hpp"
     namespace pcg_extras {
-        typedef pcg_extras::uint_x4<uint32_t,uint64_t> pcg128_t;
+        using pcg128_t = pcg_extras::uint_x4<uint32_t,uint64_t>;
     }
     #define PCG_128BIT_CONSTANT(high,low) \
             pcg128_t(high,low)
@@ -107,7 +107,7 @@ namespace pcg_extras {
 #ifndef PCG_BITCOUNT_T
     using bitcount_t = uint8_t;
 #else
-    typedef PCG_BITCOUNT_T bitcount_t;
+    using bitcount_t = PCG_BITCOUNT_T;
 #endif
 
 /*


### PR DESCRIPTION
Replace remaining `typedef` with `using`