### PR TITLE
Compatibility with boost 1.65

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ${CCTAG_USE_POSITION_INDEPENDENT_CODE})
+
+
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ")
 
 # set the path where we can find the findXXX.cmake

--- a/src/cctag/utils/Exceptions.hpp
+++ b/src/cctag/utils/Exceptions.hpp
@@ -75,6 +75,13 @@ public:
 
 	virtual ~error_info() throw( )  = default;
 
+	error_info_base * clone() const
+	{
+		error_info* p = new error_info();
+		*p = *this;
+		return p;
+	}
+
 	template<typename V>
 	This& operator+( const V& v )
 	{


### PR DESCRIPTION
- [X] add clone function for compatibility with recent boost versions
- [X] correctly initialize CMAKE_POSITION_INDEPENDENT_CODE
