### PR TITLE
Update Exceptions.hpp

### DIFF
--- a/src/cctag/utils/Exceptions.hpp
+++ b/src/cctag/utils/Exceptions.hpp
@@ -77,9 +77,7 @@ public:
 
 	error_info_base * clone() const
 	{
-		error_info* p = new error_info();
-		*p = *this;
-		return p;
+		return new error_info(*this);
 	}
 
 	template<typename V>


### PR DESCRIPTION
Sorry for accepting this the first time around. The default operator= is actually deleted (because ill-formed), so we need to implement the clone method this way. This was compiled successfully against Boost 1.65.