### PR TITLE
Fix/unique mutex use error

### DIFF
--- a/src/cctag/cuda/tag_threads.cu
+++ b/src/cctag/cuda/tag_threads.cu
@@ -73,9 +73,7 @@ void TagThreads::frameDonePost( )  { _frameDone.post( 1 ); }
 
 void TagSemaphore::wait( int n )
 {
-    std::unique_lock<std::mutex> sema_lock( _sema_mx, std::defer_lock );
-
-    sema_lock.lock();
+    std::unique_lock<std::mutex> sema_lock( _sema_mx );
     while( _sema_val - n < 0 )
     {
         _sema_cond.wait( sema_lock );
@@ -86,9 +84,7 @@ void TagSemaphore::wait( int n )
 
 void TagSemaphore::post( int n )
 {
-    std::unique_lock<std::mutex> sema_lock( _sema_mx, std::defer_lock );
-
-    sema_lock.lock();
+    std::unique_lock<std::mutex> sema_lock( _sema_mx );
     _sema_val += n;
     _sema_cond.notify_all();
     sema_lock.unlock();

--- a/src/cctag/cuda/tag_threads.cu
+++ b/src/cctag/cuda/tag_threads.cu
@@ -67,5 +67,32 @@ void TagThreads::frameReadyPost( ) { _frameReady.post( _layers ); }
 void TagThreads::frameDoneWait( )  { _frameDone.wait( _layers );  }
 void TagThreads::frameDonePost( )  { _frameDone.post( 1 ); }
 
+/*************************************************************
+ * TagSemaphore
+ *************************************************************/
+
+void TagSemaphore::wait( int n )
+{
+    std::unique_lock<std::mutex> sema_lock( _sema_mx, std::defer_lock );
+
+    sema_lock.lock();
+    while( _sema_val - n < 0 )
+    {
+        _sema_cond.wait( sema_lock );
+    }
+    _sema_val -= n;
+    sema_lock.unlock();
+}
+
+void TagSemaphore::post( int n )
+{
+    std::unique_lock<std::mutex> sema_lock( _sema_mx, std::defer_lock );
+
+    sema_lock.lock();
+    _sema_val += n;
+    _sema_cond.notify_all();
+    sema_lock.unlock();
+}
+
 }; // namespace cctag
 

--- a/src/cctag/cuda/tag_threads.h
+++ b/src/cctag/cuda/tag_threads.h
@@ -32,28 +32,21 @@ namespace cctag
 class TagPipe;
 class TagThreads;
 
+/*************************************************************
+ * TagSemaphore
+ *************************************************************/
 class TagSemaphore
 {
-    int              _sema_val;
-    std::unique_lock<std::mutex> _sema_lock;
-    std::condition_variable _sema_cond;
+    int                          _sema_val;
+    std::mutex                   _sema_mx;
+    std::condition_variable      _sema_cond;
 public:
     TagSemaphore( int init )
         : _sema_val( init )
     { }
 
-    inline void wait( int n = 1 ) {
-        _sema_lock.lock();
-        while( _sema_val - n < 0 ) _sema_cond.wait( _sema_lock );
-        _sema_val -= n;
-        _sema_lock.unlock();
-    }
-    inline void post( int n = 1 ) {
-        _sema_lock.lock();
-        _sema_val += n;
-        _sema_cond.notify_all();
-        _sema_lock.unlock();
-    }
+    void wait( int n = 1 );
+    void post( int n = 1 );
 };
 
 class TagThread : public std::thread


### PR DESCRIPTION
Several pthreads are started on the CUDA side to achieve some parallelism. std::unique_mutex is used for that, but not correctly according to C++11, leading to runtime crashes. This provides a fix. 