### PR TITLE
[build] rebuild cache whenever appveyer.yml is changed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '1.0.{build}'
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,6 @@ install:
     # - cmd: >-
     #       call cudaInstallAppveyor.cmd
 
-    # - cmd: |
-    #       cd C:\Tools\vcpkg
-    #       git pull
-    #       .\bootstrap-vcpkg.bat
-    #       cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install
@@ -62,4 +57,3 @@ build:
 
 cache:
   c:\tools\vcpkg\installed\
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,15 +12,10 @@ install:
     # - cmd: >-
     #       call cudaInstallAppveyor.cmd
 
-    # - cmd: |
-    #       cd C:\Tools\vcpkg
-    #       git pull
-    #       .\bootstrap-vcpkg.bat
-    #       cd %APPVEYOR_BUILD_FOLDER%
-
     - cmd: |
-          echo %APPVEYOR_BUILD_FOLDER%
           cd C:\Tools\vcpkg
+          git pull
+          .\bootstrap-vcpkg.bat
           cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ install:
 
     - cmd: |
           echo %APPVEYOR_BUILD_FOLDER%
-	  cd C:\Tools\vcpkg
-	  dir
-	  cd %APPVEYOR_BUILD_FOLDER%
+          cd C:\Tools\vcpkg
+	  dir /w
+          cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ install:
     #       .\bootstrap-vcpkg.bat
     #       cd %APPVEYOR_BUILD_FOLDER%
 
+    - cmd: |
+          echo %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,12 @@ install:
     # - cmd: >-
     #       call cudaInstallAppveyor.cmd
 
+    # - cmd: |
+    #       cd C:\Tools\vcpkg
+    #       git pull
+    #       .\bootstrap-vcpkg.bat
+    #       cd %APPVEYOR_BUILD_FOLDER%
+
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install
@@ -56,4 +62,5 @@ build:
   parallel: true
 
 cache:
-  c:\tools\vcpkg\installed\
+  c:\tools\vcpkg\installed\ -> appveyor.yml
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ install:
     # - cmd: >-
     #       call cudaInstallAppveyor.cmd
 
-    - cmd: |
-          cd C:\Tools\vcpkg
-          git pull
-          .\bootstrap-vcpkg.bat
-          cd %APPVEYOR_BUILD_FOLDER%
+    # - cmd: |
+    #       cd C:\Tools\vcpkg
+    #       git pull
+    #       .\bootstrap-vcpkg.bat
+    #       cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,5 +61,5 @@ build:
   parallel: true
 
 cache:
-  c:\tools\vcpkg\installed\ -> appveyor.yml
+  c:\tools\vcpkg\installed\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ install:
 
     - cmd: |
           echo %APPVEYOR_BUILD_FOLDER%
+	  cd C:\Tools\vcpkg
+	  dir
+	  cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list
     - vcpkg install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ install:
     - cmd: |
           echo %APPVEYOR_BUILD_FOLDER%
           cd C:\Tools\vcpkg
-	  dir /w
           cd %APPVEYOR_BUILD_FOLDER%
     - vcpkg upgrade --no-dry-run
     - vcpkg list


### PR DESCRIPTION
An upgrade to vcpkg's command file format (on the servers) prevents our version of vcpkg to parse them. Web pages recommend to clear the cache and run a script bootstrap-vcpkg.bat that will rebuild vcpkg.