### PR TITLE
Expose the rescaled outerEllipse

### DIFF
--- a/src/cctag/CCTag.hpp
+++ b/src/cctag/CCTag.hpp
@@ -158,7 +158,7 @@ public:
     _mHomography = homography;
   }
 
-  const cctag::numerical::geometry::Ellipse & outerEllipse() const override
+  const cctag::numerical::geometry::Ellipse & outerEllipse() const
   {
     return _outerEllipse;
   }
@@ -248,7 +248,7 @@ public:
     _rescaledOuterEllipsePoints = outerEllipsePoints;
   }
 
-  const cctag::numerical::geometry::Ellipse & rescaledOuterEllipse() const
+  const cctag::numerical::geometry::Ellipse & rescaledOuterEllipse() const override
   {
     return _rescaledOuterEllipse;
   }

--- a/src/cctag/ICCTag.hpp
+++ b/src/cctag/ICCTag.hpp
@@ -38,7 +38,7 @@ public:
 	virtual float y() const = 0;
 	virtual MarkerID id() const = 0;
 	virtual int getStatus() const = 0;
-    virtual const numerical::geometry::Ellipse & outerEllipse() const = 0;
+    virtual const cctag::numerical::geometry::Ellipse & rescaledOuterEllipse() const = 0;
 
     virtual ~ICCTag() = default;
 
@@ -49,9 +49,9 @@ protected:
     float _x;
     float _y;
     MarkerID _id;
-        int _status; // WARNING: only markers with status == 1 are the valid ones. (status available via getStatus()) 
-                     // A marker correctly detected and identified has a status 1.
-                     // Otherwise, it can be detected but not correctly identified.
+    int _status; // WARNING: only markers with status == 1 are the valid ones. (status available via getStatus()) 
+                 // A marker correctly detected and identified has a status 1.
+                 // Otherwise, it can be detected but not correctly identified.
 };
 
 inline ICCTag* new_clone(const ICCTag& a)


### PR DESCRIPTION
The rescaled outerEllipse is in the coordinate system of the input
image, while the internal ellipse is relative to a pyramid level.