### PR TITLE
CUDA Cub dep has been removed?

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,15 +76,6 @@ Then, in order to build just pass the location of `CCTagConfig.cmake` from the c
 cmake .. -DCCTag_DIR=$CCTAG_INSTALL/lib/cmake/CCTag/
 ```
 
-----------
-
-Note 1: CCTag uses NVidia CUB (CCTag includes a copy of CUB from CUDA 7.0).
-Several CUB functions are known to fail with a few NVidia cards including our reference card,
-the GTX 980 Ti.
-The CUB that is included with CUDA 7.5 does not solve this problem.
-
-----------
-
 ## Docker Image
 
 A docker image can be built using the Ubuntu based [Dockerfile](Dockerfile),which is based on nvidia/cuda image (https://hub.docker.com/r/nvidia/cuda/)

--- a/cmake/config.hpp.in
+++ b/cmake/config.hpp.in
@@ -26,8 +26,6 @@
 
 #ifdef CCTAG_WITH_CUDA
 
-  #define CUB_CDP
-
   #ifndef CCTAG_HAVE_SHFL_DOWN_SYNC
   #cmakedefine CCTAG_HAVE_SHFL_DOWN_SYNC
   #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,7 +83,7 @@ if(CCTAG_WITH_CUDA)
   # set(CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE ON)
   # set(BUILD_SHARED_LIBS ON)
 
-  set(CUDA_NVCC_FLAGS  "${CUDA_NVCC_FLAGS};-DCUB_CDP")
+  set(CUDA_NVCC_FLAGS  "${CUDA_NVCC_FLAGS}")
 
   # this must go before CUDA_ADD_LIBRARY otherwise we won't be able to add it
   # after
@@ -108,7 +108,7 @@ if(CCTAG_WITH_CUDA)
   endif()
 
   target_compile_definitions(CCTag
-                         PUBLIC -DCCTAG_WITH_CUDA -DCUB_CDP
+                         PUBLIC -DCCTAG_WITH_CUDA
                          PRIVATE ${TBB_DEFINITIONS})
 
   if(CCTAG_HAVE_SHFL_DOWN_SYNC)


### PR DESCRIPTION
Came across this- PR #110 .

So I think this section is no longer correct. But searching the repo shows a couple of places where the flag is used in the cmake files- not sure if that needs cleanup, or I'm mistaken by the title of PR #110 .