### PR TITLE
Fix/cuda flex pinned mem

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,7 +185,7 @@ if(CCTAG_WITH_CUDA)
   endif()
 
   target_compile_definitions(CCTag
-                         PUBLIC -DCCTAG_WITH_CUDA
+                         PUBLIC -DCCTAG_WITH_CUDA -DBOOST_NO_CXX11_CONSTEXPR
                          PRIVATE ${TBB_DEFINITIONS})
 
   if(CCTAG_HAVE_SHFL_DOWN_SYNC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set( CCTag_cpp
         ./cctag/geometry/Distance.cpp
         ./cctag/geometry/Ellipse.cpp
         ./cctag/geometry/EllipseFromPoints.cpp
+        ./cctag/utils/Accum.cpp
         ./cctag/utils/FileDebug.cpp
         ./cctag/utils/LogTime.cpp
         ./cctag/utils/Talk.cpp
@@ -71,6 +72,7 @@ set( CCTag_HEADERS
         ./cctag/geometry/EllipseFromPoints.hpp
         ./cctag/geometry/Point.hpp
         ./cctag/optimization/conditioner.hpp
+        ./cctag/utils/Accum.hpp
         ./cctag/utils/Debug.hpp
         ./cctag/utils/Defines.hpp
         ./cctag/utils/Exceptions.hpp

--- a/src/cctag/CCTag.cpp
+++ b/src/cctag/CCTag.cpp
@@ -18,7 +18,6 @@
 #include <opencv2/core/core_c.h>
 
 #include <boost/foreach.hpp>
-#include <boost/timer.hpp>
 #include <boost/array.hpp>
 #include <boost/mpl/bool.hpp>
 

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -731,12 +731,16 @@ void createImageForVoteResultDebug(
 
 #ifdef CCTAG_WITH_CUDA
 cctag::TagPipe* initCuda( int      pipeId,
-                           uint32_t width,
-                           uint32_t height, 
-                           const Parameters & params,
-                           cctag::logtime::Mgmt* durations )
+                          uint32_t width,
+                          uint32_t height, 
+                          const Parameters & params,
+                          cctag::logtime::Mgmt* durations )
 {
-    if( cudaPipelines.size() <= pipeId ) {
+    PinnedCounters::setGlobalMax( params._pinnedCounters,
+                                  params._pinnedNearbyPoints );
+
+    if( cudaPipelines.size() <= pipeId )
+    {
         cudaPipelines.resize( pipeId+1 );
     }
 

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -34,7 +34,7 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/unordered/unordered_set.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <cmath>
@@ -584,7 +584,7 @@ void cctagDetectionFromEdges(
   createImageForVoteResultDebug(src, pyramidLevel);
 
   // Set some timers
-  boost::timer t3;
+  boost::timer::cpu_timer t3;
   boost::posix_time::ptime tstart0(boost::posix_time::microsec_clock::local_time());
 
   std::size_t nSegmentOut = 0;

--- a/src/cctag/Multiresolution.cpp
+++ b/src/cctag/Multiresolution.cpp
@@ -16,7 +16,7 @@
 #include <cctag/Detection.hpp>
 #include <cctag/utils/Talk.hpp> // for DO_TALK macro
 
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <cmath>

--- a/src/cctag/Params.cpp
+++ b/src/cctag/Params.cpp
@@ -68,6 +68,8 @@ Parameters::Parameters(std::size_t nCrowns)
   , _doIdentification(kDefaultDoIdentification)
   , _maxEdges(kDefaultMaxEdges)
   , _useCuda(kDefaultUseCuda)
+  , _pinnedCounters( kDefaultPinnedCounters )
+  , _pinnedNearbyPoints( kDefaultPinnedNearbyPoints )
   , _debugDir("")
 {
     _nCircles = 2 * _nCrowns;

--- a/src/cctag/Params.hpp
+++ b/src/cctag/Params.hpp
@@ -62,6 +62,8 @@ static constexpr bool kDefaultUseCuda = true;
 #else
 static constexpr bool kDefaultUseCuda = false;
 #endif
+static constexpr size_t kDefaultPinnedCounters     = 100;
+static constexpr size_t kDefaultPinnedNearbyPoints = 60;
 
 static const std::string kParamCannyThrLow("kParamCannyThrLow");
 static const std::string kParamCannyThrHigh("kParamCannyThrHigh");
@@ -95,6 +97,8 @@ static const std::string kParamWriteOutput("kParamWriteOutput");
 static const std::string kParamDoIdentification("kParamDoIdentification");
 static const std::string kParamMaxEdges("kParamMaxEdges");
 static const std::string kUseCuda("kUseCuda");
+static const std::string kPinnedCounters("kPinnedCounters");
+static const std::string kPinnedNearbyPoints("kPinnedNearbyPoints");
 
 static const std::size_t kWeight = INV_GRAD_WEIGHT;
 
@@ -180,6 +184,10 @@ struct Parameters
     uint32_t _maxEdges;
     ///  if compiled with CCTAG_WITH_CUDA, whether to use cuda algorithm or not, otherwise it is ignored
     bool _useCuda;
+    /// if _useCuda, physical memory reserved for internal counters, otherwise unused
+    size_t _pinnedCounters;
+    /// if _useCuda, physical memory reserved for point detection, otherwise unused
+    size_t _pinnedNearbyPoints;
     ///  prefix for debug output
     std::string _debugDir;
 
@@ -224,6 +232,8 @@ struct Parameters
         ar& BOOST_SERIALIZATION_NVP(_doIdentification);
         ar& BOOST_SERIALIZATION_NVP(_maxEdges);
         ar& BOOST_SERIALIZATION_NVP(_useCuda);
+        ar& BOOST_SERIALIZATION_NVP(_pinnedCounters);
+        ar& BOOST_SERIALIZATION_NVP(_pinnedNearbyPoints);
         _nCircles = 2 * _nCrowns;
     }
 

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -29,7 +29,6 @@
 #include <boost/multi_array/subarray.hpp>
 #include <boost/container/flat_set.hpp>
 
-#include <boost/timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <deque>

--- a/src/cctag/cuda/pinned_counters.h
+++ b/src/cctag/cuda/pinned_counters.h
@@ -33,12 +33,14 @@ public:
     PinnedCounters( );
     ~PinnedCounters( );
 
+    static void setGlobalMax( int max_counters, int max_points );
+
     static void init( int tagPipe );
     static void release( int tagPipe );
 
     static int& getCounter( int tagPipe );
 
-    /** Returns a reference to a NearyPoint-sized section of host-side
+    /** Returns a reference to a NearbyPoint-sized section of host-side
      *  pinned memory.
      *  This function is only used by the constructors of the class
      *  CCTag in cctag before identification.
@@ -59,8 +61,9 @@ private:
 
     std::mutex _lock;
 
-    static const int _max_counters;
-    static const int _max_points;
+    static const bool _max_values_set;
+    static const int  _max_counters;
+    static const int  _max_points;
 
     void         obj_init( );
     int&         obj_getCounter( );

--- a/src/cctag/cuda/pinned_counters.h
+++ b/src/cctag/cuda/pinned_counters.h
@@ -61,9 +61,9 @@ private:
 
     std::mutex _lock;
 
-    static const bool _max_values_set;
-    static const int  _max_counters;
-    static const int  _max_points;
+    static bool _max_values_set;
+    static int  _max_counters;
+    static int  _max_points;
 
     void         obj_init( );
     int&         obj_getCounter( );

--- a/src/cctag/filter/cvRecode.cpp
+++ b/src/cctag/filter/cvRecode.cpp
@@ -18,7 +18,7 @@
 #include "cctag/Params.hpp"
 #include "cctag/utils/Talk.hpp" // do DO_TALK macro
 
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <cstdlib> // for ::abs
 #include <climits>
@@ -47,7 +47,7 @@ void cvRecodedCanny(
   int debug_info_level,
   const cctag::Parameters* params )
 {
-  boost::timer t;  
+  boost::timer::cpu_timer t;  
   std::vector<uchar*> stack;
   uchar** stack_top = nullptr, ** stack_bottom = nullptr;
   
@@ -166,8 +166,9 @@ void cvRecodedCanny(
 #define CANNY_PUSH( d )    *( d ) = (uchar)2, *stack_top++ = ( d )
 #define CANNY_POP( d )     ( d )  = *--stack_top
 
+  t.stop();
   DO_TALK( CCTAG_COUT_DEBUG( "Canny 1 took: " << t.elapsed() ); );
-  t.restart();
+  t.resume();
 
   // calculate magnitude and angle of gradient, perform non-maxima supression.
   // fill the map with one of the following values:
@@ -328,6 +329,7 @@ void cvRecodedCanny(
     mag_buf[2] = _mag;
   }
 
+  t.stop();
   DO_TALK( CCTAG_COUT_DEBUG( "Canny 2 took : " << t.elapsed() ); )
 
 #ifdef DEBUG_MAGMAP_BY_GRIFF
@@ -354,7 +356,7 @@ void cvRecodedCanny(
 	delete[] write_mag;
   }
 #endif // DEBUG_MAGMAP_BY_GRIFF
-  t.restart();
+  t.resume();
 
   // now track the edges (hysteresis thresholding)
   while( stack_top > stack_bottom )
@@ -389,9 +391,9 @@ void cvRecodedCanny(
       CANNY_PUSH( m + mapstep + 1 );
   }
 
+  t.stop();
   DO_TALK( CCTAG_COUT_DEBUG( "Canny 3 took : " << t.elapsed() ); )
-
-  t.restart();
+  t.resume();
 
   // the final pass, form the final image
   for( i = 0; i < size.height; i++ )

--- a/src/cctag/utils/Accum.cpp
+++ b/src/cctag/utils/Accum.cpp
@@ -1,0 +1,52 @@
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/median.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+
+#include <cctag/utils/Accum.hpp>
+
+namespace bacc  = boost::accumulators;
+
+namespace cctag
+{
+
+void VarianceAccumulator::insert( float f )
+{
+    acc.push_back( f );
+}
+
+float VarianceAccumulator::result( ) const
+{
+    bacc::accumulator_set< float, bacc::features< bacc::tag::variance > > v;
+    for( auto f : acc ) v.operator()(f);
+    return bacc::variance( v );
+}
+
+void MeanAccumulator::insert( float f )
+{
+    acc.push_back( f );
+}
+
+float MeanAccumulator::result( ) const
+{
+    bacc::accumulator_set< float, bacc::features< bacc::tag::mean > > v;
+    for( auto f : acc ) v.operator()(f);
+    return bacc::mean( v );
+}
+
+void LMeanAccumulator::insert( long f )
+{
+    acc.push_back( f );
+}
+
+long LMeanAccumulator::result( ) const
+{
+    bacc::accumulator_set< long,  bacc::features< bacc::tag::mean > > v;
+    for( auto f : acc ) v.operator()(f);
+    return bacc::mean( v );
+}
+
+}; // namespace cctag
+

--- a/src/cctag/utils/Accum.hpp
+++ b/src/cctag/utils/Accum.hpp
@@ -1,0 +1,43 @@
+#ifndef _CCTAG_ACCUMULATOR
+#define _CCTAG_ACCUMULATOR
+
+#include <vector>
+
+namespace cctag
+{
+
+class VarianceAccumulator
+{
+    std::vector<float> acc;
+
+public:
+    VarianceAccumulator( ) { }
+    void insert( float f );
+    float result( ) const;
+
+};
+
+class MeanAccumulator
+{
+    std::vector<float> acc;
+
+public:
+    MeanAccumulator( ) { }
+    void insert( float f );
+    float result( ) const;
+};
+
+class LMeanAccumulator
+{
+    std::vector<long> acc;
+
+public:
+    LMeanAccumulator( ) { }
+    void insert( long f );
+    long result( ) const;
+};
+
+}; // namespace cctag
+
+#endif
+

--- a/src/cctag/utils/LogTime.cpp
+++ b/src/cctag/utils/LogTime.cpp
@@ -19,7 +19,7 @@ void Mgmt::Measurement::print( std::ostream& ostr ) const
 {
     if( ! _probe ) return;
     ostr << _probe << ": "
-         << bacc::mean(_ms_acc) << "ms "
+         << _ms_acc.result() << "ms "
          // << bacc::mean(_us_acc) << "us"
          << std::endl;
 }

--- a/src/cctag/utils/LogTime.hpp
+++ b/src/cctag/utils/LogTime.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics.hpp>
+
+#include <cctag/utils/Accum.hpp>
 
 #include <cstddef>
 #include <string>
@@ -19,7 +19,6 @@ namespace cctag {
 namespace logtime {
 
 namespace btime = boost::posix_time;
-namespace bacc  = boost::accumulators;
 
 struct Mgmt
 {
@@ -32,8 +31,8 @@ struct Mgmt
 
         void log( const char* probename, const btime::time_duration& duration ) {
             if( ! _probe ) _probe = strdup( probename );
-            _ms_acc( duration.total_milliseconds() );
-            _us_acc( duration.total_microseconds() );
+            _ms_acc.insert( duration.total_milliseconds() );
+            _us_acc.insert( duration.total_microseconds() );
         }
 
         bool doPrint( ) const;
@@ -42,8 +41,8 @@ struct Mgmt
 
     private:
         const char* _probe;
-        bacc::accumulator_set<long, bacc::features<bacc::tag::mean> > _ms_acc;
-        bacc::accumulator_set<long, bacc::features<bacc::tag::mean> > _us_acc;
+        LMeanAccumulator _ms_acc;
+        LMeanAccumulator _us_acc;
     };
 
     btime::ptime             _previous_time;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

When the CUDA code is used on an image with more than 60 CCTag candidates, a hard-coded limit was reached. The same is the case for point counters. Having such a limit is required because candidate structures are kept in pinned memory, which means that the program is actually keeping part of the computer's physical (not only virtual) memory until the CCTag object is deleted.

Now, this limit can now be set as a parameter.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

- Two new variables in cctag::Parameters, _pinnedCounters (default 100) and _pinnedNearbyPoints (default 60).

## Implementation remarks

- the boost constexpr handling is indepedent but was required
- also boost/timer.hpp was replaced with boost/timer/timer.hpp, objects of class timer were replaced by cpu_timer
 
<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
