### PR TITLE
Avoid boost bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set( CCTag_cpp
         ./cctag/geometry/Distance.cpp
         ./cctag/geometry/Ellipse.cpp
         ./cctag/geometry/EllipseFromPoints.cpp
+        ./cctag/utils/Accum.cpp
         ./cctag/utils/FileDebug.cpp
         ./cctag/utils/LogTime.cpp
         ./cctag/utils/Talk.cpp
@@ -71,6 +72,7 @@ set( CCTag_HEADERS
         ./cctag/geometry/EllipseFromPoints.hpp
         ./cctag/geometry/Point.hpp
         ./cctag/optimization/conditioner.hpp
+        ./cctag/utils/Accum.hpp
         ./cctag/utils/Debug.hpp
         ./cctag/utils/Defines.hpp
         ./cctag/utils/Exceptions.hpp

--- a/src/cctag/utils/Accum.cpp
+++ b/src/cctag/utils/Accum.cpp
@@ -1,0 +1,52 @@
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/median.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+
+#include <cctag/utils/Accum.hpp>
+
+namespace bacc  = boost::accumulators;
+
+namespace cctag
+{
+
+void VarianceAccumulator::insert( float f )
+{
+    acc.push_back( f );
+}
+
+float VarianceAccumulator::result( ) const
+{
+    bacc::accumulator_set< float, bacc::features< bacc::tag::variance > > v;
+    for( auto f : acc ) v.operator()(f);
+    return bacc::variance( v );
+}
+
+void MeanAccumulator::insert( float f )
+{
+    acc.push_back( f );
+}
+
+float MeanAccumulator::result( ) const
+{
+    bacc::accumulator_set< float, bacc::features< bacc::tag::mean > > v;
+    for( auto f : acc ) v.operator()(f);
+    return bacc::mean( v );
+}
+
+void LMeanAccumulator::insert( long f )
+{
+    acc.push_back( f );
+}
+
+long LMeanAccumulator::result( ) const
+{
+    bacc::accumulator_set< long,  bacc::features< bacc::tag::mean > > v;
+    for( auto f : acc ) v.operator()(f);
+    return bacc::mean( v );
+}
+
+}; // namespace cctag
+

--- a/src/cctag/utils/Accum.hpp
+++ b/src/cctag/utils/Accum.hpp
@@ -14,7 +14,6 @@ public:
     VarianceAccumulator( ) { }
     void insert( float f );
     float result( ) const;
-
 };
 
 class MeanAccumulator

--- a/src/cctag/utils/Accum.hpp
+++ b/src/cctag/utils/Accum.hpp
@@ -1,5 +1,4 @@
-#ifndef _CCTAG_ACCUMULATOR
-#define _CCTAG_ACCUMULATOR
+#pragma once
 
 #include <vector>
 
@@ -11,7 +10,7 @@ class VarianceAccumulator
     std::vector<float> acc;
 
 public:
-    VarianceAccumulator( ) { }
+    VarianceAccumulator() = default;
     void insert( float f );
     float result( ) const;
 };
@@ -21,7 +20,7 @@ class MeanAccumulator
     std::vector<float> acc;
 
 public:
-    MeanAccumulator( ) { }
+    MeanAccumulator() = default;
     void insert( float f );
     float result( ) const;
 };
@@ -31,12 +30,10 @@ class LMeanAccumulator
     std::vector<long> acc;
 
 public:
-    LMeanAccumulator( ) { }
+    LMeanAccumulator() = default;
     void insert( long f );
     long result( ) const;
 };
 
 }; // namespace cctag
-
-#endif
 

--- a/src/cctag/utils/Accum.hpp
+++ b/src/cctag/utils/Accum.hpp
@@ -1,0 +1,43 @@
+#ifndef _CCTAG_ACCUMULATOR
+#define _CCTAG_ACCUMULATOR
+
+#include <vector>
+
+namespace cctag
+{
+
+class VarianceAccumulator
+{
+    std::vector<float> acc;
+
+public:
+    VarianceAccumulator( ) { }
+    void insert( float f );
+    float result( ) const;
+
+};
+
+class MeanAccumulator
+{
+    std::vector<float> acc;
+
+public:
+    MeanAccumulator( ) { }
+    void insert( float f );
+    float result( ) const;
+};
+
+class LMeanAccumulator
+{
+    std::vector<long> acc;
+
+public:
+    LMeanAccumulator( ) { }
+    void insert( long f );
+    long result( ) const;
+};
+
+}; // namespace cctag
+
+#endif
+

--- a/src/cctag/utils/LogTime.cpp
+++ b/src/cctag/utils/LogTime.cpp
@@ -19,7 +19,7 @@ void Mgmt::Measurement::print( std::ostream& ostr ) const
 {
     if( ! _probe ) return;
     ostr << _probe << ": "
-         << bacc::mean(_ms_acc) << "ms "
+         << _ms_acc.result() << "ms "
          // << bacc::mean(_us_acc) << "us"
          << std::endl;
 }

--- a/src/cctag/utils/LogTime.hpp
+++ b/src/cctag/utils/LogTime.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics.hpp>
+
+#include <cctag/utils/Accum.hpp>
 
 #include <cstddef>
 #include <string>
@@ -19,7 +19,6 @@ namespace cctag {
 namespace logtime {
 
 namespace btime = boost::posix_time;
-namespace bacc  = boost::accumulators;
 
 struct Mgmt
 {
@@ -32,8 +31,8 @@ struct Mgmt
 
         void log( const char* probename, const btime::time_duration& duration ) {
             if( ! _probe ) _probe = strdup( probename );
-            _ms_acc( duration.total_milliseconds() );
-            _us_acc( duration.total_microseconds() );
+            _ms_acc.insert( duration.total_milliseconds() );
+            _us_acc.insert( duration.total_microseconds() );
         }
 
         bool doPrint( ) const;
@@ -42,8 +41,8 @@ struct Mgmt
 
     private:
         const char* _probe;
-        bacc::accumulator_set<long, bacc::features<bacc::tag::mean> > _ms_acc;
-        bacc::accumulator_set<long, bacc::features<bacc::tag::mean> > _us_acc;
+        LMeanAccumulator _ms_acc;
+        LMeanAccumulator _us_acc;
     };
 
     btime::ptime             _previous_time;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Avoids the constexpr bug encountered with boost 1.73 by moving the boost::accumulator into some utility classes.
By drawing values from a simple std::vector instead of advanced classes, the bug is apparently not triggered.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
