### PR TITLE
Fix/cuda flex pinned mem

### DIFF
--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -731,12 +731,16 @@ void createImageForVoteResultDebug(
 
 #ifdef CCTAG_WITH_CUDA
 cctag::TagPipe* initCuda( int      pipeId,
-                           uint32_t width,
-                           uint32_t height, 
-                           const Parameters & params,
-                           cctag::logtime::Mgmt* durations )
+                          uint32_t width,
+                          uint32_t height, 
+                          const Parameters & params,
+                          cctag::logtime::Mgmt* durations )
 {
-    if( cudaPipelines.size() <= pipeId ) {
+    PinnedCounters::setGlobalMax( params._pinnedCounters,
+                                  params._pinnedNearbyPoints );
+
+    if( cudaPipelines.size() <= pipeId )
+    {
         cudaPipelines.resize( pipeId+1 );
     }
 

--- a/src/cctag/Params.cpp
+++ b/src/cctag/Params.cpp
@@ -68,6 +68,8 @@ Parameters::Parameters(std::size_t nCrowns)
   , _doIdentification(kDefaultDoIdentification)
   , _maxEdges(kDefaultMaxEdges)
   , _useCuda(kDefaultUseCuda)
+  , _pinnedCounters( kDefaultPinnedCounters )
+  , _pinnedNearbyPoints( kDefaultPinnedNearbyPoints )
   , _debugDir("")
 {
     _nCircles = 2 * _nCrowns;

--- a/src/cctag/Params.hpp
+++ b/src/cctag/Params.hpp
@@ -62,6 +62,8 @@ static constexpr bool kDefaultUseCuda = true;
 #else
 static constexpr bool kDefaultUseCuda = false;
 #endif
+static constexpr size_t kDefaultPinnedCounters     = 100;
+static constexpr size_t kDefaultPinnedNearbyPoints = 60;
 
 static const std::string kParamCannyThrLow("kParamCannyThrLow");
 static const std::string kParamCannyThrHigh("kParamCannyThrHigh");
@@ -95,6 +97,8 @@ static const std::string kParamWriteOutput("kParamWriteOutput");
 static const std::string kParamDoIdentification("kParamDoIdentification");
 static const std::string kParamMaxEdges("kParamMaxEdges");
 static const std::string kUseCuda("kUseCuda");
+static const std::string kPinnedCounters("kPinnedCounters");
+static const std::string kPinnedNearbyPoints("kPinnedNearbyPoints");
 
 static const std::size_t kWeight = INV_GRAD_WEIGHT;
 
@@ -182,6 +186,18 @@ struct Parameters
     uint32_t _maxEdges;
     ///  if compiled with CCTAG_WITH_CUDA, whether to use cuda algorithm or not, otherwise it is ignored
     bool _useCuda;
+
+    /** If _useCuda==true, the number of ints that are allocated in
+     *  physical memory reserved for internal counters, otherwise unused.
+     */
+    size_t _pinnedCounters;
+
+    /** if _useCuda==true, physical memory reserved for point detection, otherwise unused.
+     *  Allocates _pinnedNearbyPoint*sizeof(NearbyPoint).
+     *  It is expected that sizeof(NearbyPoint)==96.
+     */
+    size_t _pinnedNearbyPoints;
+
     ///  prefix for debug output
     std::string _debugDir;
 
@@ -226,6 +242,8 @@ struct Parameters
         ar& BOOST_SERIALIZATION_NVP(_doIdentification);
         ar& BOOST_SERIALIZATION_NVP(_maxEdges);
         ar& BOOST_SERIALIZATION_NVP(_useCuda);
+        ar& BOOST_SERIALIZATION_NVP(_pinnedCounters);
+        ar& BOOST_SERIALIZATION_NVP(_pinnedNearbyPoints);
         _nCircles = 2 * _nCrowns;
     }
 

--- a/src/cctag/cuda/pinned_counters.h
+++ b/src/cctag/cuda/pinned_counters.h
@@ -33,12 +33,14 @@ public:
     PinnedCounters( );
     ~PinnedCounters( );
 
+    static void setGlobalMax( int max_counters, int max_points );
+
     static void init( int tagPipe );
     static void release( int tagPipe );
 
     static int& getCounter( int tagPipe );
 
-    /** Returns a reference to a NearyPoint-sized section of host-side
+    /** Returns a reference to a NearbyPoint-sized section of host-side
      *  pinned memory.
      *  This function is only used by the constructors of the class
      *  CCTag in cctag before identification.
@@ -59,8 +61,9 @@ private:
 
     std::mutex _lock;
 
-    static const int _max_counters;
-    static const int _max_points;
+    static bool _max_values_set;
+    static int  _max_counters;
+    static int  _max_points;
 
     void         obj_init( );
     int&         obj_getCounter( );


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

When the CUDA code is used on an image with more than 60 CCTag candidates, a hard-coded limit was reached. The same is the case for point counters. Having such a limit is required because candidate structures are kept in pinned memory, which means that the program is actually keeping part of the computer's physical (not only virtual) memory until the CCTag object is deleted.

Now, this limit can now be set as a parameter.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

- Two new variables in cctag::Parameters, _pinnedCounters (default 100) and _pinnedNearbyPoints (default 60).

## Implementation remarks

- the boost constexpr handling is independent but was required
- also boost/timer.hpp was replaced with boost/timer/timer.hpp, objects of class timer were replaced by cpu_timer
 
<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
