### PR TITLE
[apps] improved detection app

### DIFF
--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -117,9 +117,4 @@ add_executable(simulation ${CCTagSimulation_cpp})
 target_include_directories(simulation PUBLIC ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(simulation PUBLIC ${OpenCV_LIBS})
 
-foreach(_app detection regression simulation)
-  set_target_properties(${_app} PROPERTIES VERSION ${PROJECT_VERSION})
-  set_target_properties(${_app} PROPERTIES DEBUG_POSTFIX "d")
-endforeach()
-
 install(TARGETS detection regression simulation DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -15,105 +15,87 @@
 namespace cctag {
 
 
-CmdLine::CmdLine( )
-    : _filename( "" )
-    , _nRings( 0 )
-    , _cctagBankFilename( "" )
-    , _paramsFilename( "" )
-    , _outputFolderName( "" )
-    , _saveDetectedImage(false)
-    , _showUnreliableDetections(false)
-#ifdef CCTAG_WITH_CUDA
-    , _switchSync( false )
-    , _debugDir( "" )
-    , _useCuda( false )
-    , _parallel( 1 )
-#endif
-	, _allParams("Program for detecting CCTags in one image, in a directory or in a video\n"
+CmdLine::CmdLine( ) :
+        _allParams("Program for detecting CCTags in one image, in a directory or in a video\n"
                "For each image or video frame it detects the markers and it shows the image with a graphical overlay"
                "showing the center of the tag, its ID and the outer ellipse")
-{ 
-	using namespace boost::program_options;
+{
+    using namespace boost::program_options;
 
-	options_description required("Required input parameters");
-	required.add_options()
-		("input,i", value<std::string>(&_filename)->required(), "Path to an image (JPG, PNG) or video (avi, mov) "
-                     "or camera index for live capture (0, 1...) or to a directory containing the images to process")
-		("nbrings,n", value<std::size_t>(&_nRings)->required(), "Number of rings of the CCTags to detect");
+    options_description required("Required input parameters");
+    required.add_options()
+        ("input,i", value<std::string>(&_filename)->required(), "Path to an image (JPG, PNG) or video (avi, mov) "
+             "or camera index for live capture (0, 1...) or to a directory containing the images to process")
+        ("nbrings,n", value<std::size_t>(&_nRings)->required(), "Number of rings of the CCTags to detect");
 
-	options_description optional("Optional parameters");
-	optional.add_options()
-		("bank,b", value<std::string>(&_cctagBankFilename)->default_value(_cctagBankFilename), "Path to a bank parameter file, e.g. 4Crowns/ids.txt")
-		("params,p", value<std::string>(&_paramsFilename)->default_value(_paramsFilename), "Path to configuration XML file")
-		("output,o", value<std::string>(&_outputFolderName)->default_value(_outputFolderName), "Output folder name")
-                ("save-detected-image,s", bool_switch(&_saveDetectedImage), "Save an image with the graphical overlay of the detected tags. "
-                     "For single images the saved images will have a '_detected' suffix and it will be placed either in "
-                     "the current directory or in the directory given by --output. For videos a file named #####.png "
-                     "will be saved instead with the #s representing the zero-padded frame number, either in the current directory "
-                     "or in the directory given by --output.")
-                ("show-unreliable,u", bool_switch(&_showUnreliableDetections), "Show the unreliable tags (marker id = -1)")
+    options_description optional("Optional parameters");
+    optional.add_options()
+        ("bank,b", value<std::string>(&_cctagBankFilename)->default_value(_cctagBankFilename), "Path to a bank parameter file, e.g. 4Crowns/ids.txt")
+        ("params,p", value<std::string>(&_paramsFilename)->default_value(_paramsFilename), "Path to configuration XML file")
+        ("output,o", value<std::string>(&_outputFolderName)->default_value(_outputFolderName), "Output folder name")
+        ("save-detected-image,s", bool_switch(&_saveDetectedImage), "Save an image with the graphical overlay of the detected tags. "
+             "For single images the saved images will have a '_detected' suffix and it will be placed either in "
+             "the current directory or in the directory given by --output. For videos a file named #####.png "
+             "will be saved instead with the #s representing the zero-padded frame number, either in the current directory "
+             "or in the directory given by --output.")
+        ("show-unreliable,u", bool_switch(&_showUnreliableDetections), "Show the unreliable tags (marker id = -1)")
 #ifdef CCTAG_WITH_CUDA
-		("sync", bool_switch(&_switchSync), "CUDA debug option, run all CUDA ops synchronously")
-		("use-cuda", bool_switch(&_useCuda), "Select GPU code instead of CPU code")
-		("debug-dir", value<std::string>(&_debugDir)->default_value(_debugDir), "Path storing image to debug intermediate GPU results")
-		("parallel", value<int>(&_parallel)->default_value(_parallel), "Use <n> CUDA pipes concurrently (default 1)")
+        ("sync", bool_switch(&_switchSync), "CUDA debug option, run all CUDA ops synchronously")
+        ("use-cuda", bool_switch(&_useCuda), "Select GPU code instead of CPU code")
+        ("debug-dir", value<std::string>(&_debugDir)->default_value(_debugDir), "Path storing image to debug intermediate GPU results")
+        ("parallel", value<int>(&_parallel)->default_value(_parallel), "Use <n> CUDA pipes concurrently (default 1)")
 #endif
-		;
+            ;
 
-	_allParams.add(required).add(optional);
+    _allParams.add(required).add(optional);
 }
 
-bool CmdLine::parse( int argc, char* argv[] )
+bool CmdLine::parse(int argc, char* argv[])
 {
+    using namespace boost::program_options;
 
-	using namespace boost::program_options;
-
-	variables_map vm;
-	try
-	{
-		store(parse_command_line(argc, argv, _allParams), vm);
-		if (vm.count("help") || (argc == 1))
-		{
-			return false;
-		}
-		notify(vm);
-	}
-	catch (const std::exception& e)
-	{
-		std::cout << e.what() << std::endl;
-		return false;
-	}
+    variables_map vm;
+    try
+    {
+        store(parse_command_line(argc, argv, _allParams), vm);
+        if(vm.count("help") || (argc == 1))
+        {
+            return false;
+        }
+        notify(vm);
+    }
+    catch(const std::exception& e)
+    {
+        std::cout << e.what() << std::endl;
+        return false;
+    }
     return true;
 }
 
-void CmdLine::print( const char* const argv0 ) const
+void CmdLine::print(const char* const argv0) const
 {
     std::cout << "You called " << argv0 << " with:" << std::endl
-         << "    --input     " << _filename << std::endl
-         << "    --nbrings     " << _nRings << std::endl
-         << "    --bank      " << _cctagBankFilename << std::endl
-         << "    --params    " << _paramsFilename << std::endl
-         << "    --output    " << _outputFolderName << std::endl;
+              << "    --input     " << _filename << std::endl
+              << "    --nbrings     " << _nRings << std::endl
+              << "    --bank      " << _cctagBankFilename << std::endl
+              << "    --params    " << _paramsFilename << std::endl
+              << "    --output    " << _outputFolderName << std::endl;
     if(_saveDetectedImage)
         std::cout << "    --save-detected-image" << std::endl;
     if(_showUnreliableDetections)
         std::cout << "    --show-unreliable" << std::endl;
 #ifdef CCTAG_WITH_CUDA
-	std::cout << "    --parallel " << _parallel << std::endl;
-    if( _switchSync )
+    std::cout << "    --parallel " << _parallel << std::endl;
+    if(_switchSync)
         std::cout << "    --sync " << std::endl;
-    if( _debugDir != "" )
+    if(!_debugDir.empty())
         std::cout << "    --debug-dir " << _debugDir << std::endl;
-    if( _useCuda )
+    if(_useCuda)
         std::cout << "    --use-cuda " << std::endl;
 #endif
     std::cout << std::endl;
 }
 
-void CmdLine::usage( const char* const argv0 ) const
-{
-	std::cout << _allParams << std::endl;
-}
+void CmdLine::usage(const char* const argv0) const { std::cout << _allParams << std::endl; }
 
 }
-

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -75,7 +75,7 @@ bool CmdLine::parse( int argc, char* argv[] )
     return true;
 }
 
-void CmdLine::print( const char* const argv0 )
+void CmdLine::print( const char* const argv0 ) const
 {
     std::cout << "You called " << argv0 << " with:" << std::endl
          << "    --input     " << _filename << std::endl
@@ -95,7 +95,7 @@ void CmdLine::print( const char* const argv0 )
     std::cout << std::endl;
 }
 
-void CmdLine::usage( const char* const argv0 )
+void CmdLine::usage( const char* const argv0 ) const
 {
 	std::cout << _allParams << std::endl;
 }

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -21,6 +21,8 @@ CmdLine::CmdLine( )
     , _cctagBankFilename( "" )
     , _paramsFilename( "" )
     , _outputFolderName( "" )
+    , _saveDetectedImage(false)
+    , _showUnreliableDetections(false)
 #ifdef CCTAG_WITH_CUDA
     , _switchSync( false )
     , _debugDir( "" )
@@ -41,6 +43,8 @@ CmdLine::CmdLine( )
 		("bank,b", value<std::string>(&_cctagBankFilename)->default_value(_cctagBankFilename), "Path to a bank parameter file, e.g. 4Crowns/ids.txt")
 		("params,p", value<std::string>(&_paramsFilename)->default_value(_paramsFilename), "Path to configuration XML file")
 		("output,o", value<std::string>(&_outputFolderName)->default_value(_outputFolderName), "Output folder name")
+                ("save-detected-image,s", bool_switch(&_saveDetectedImage), "Save an image with the graphical overlay of the detected tags")
+                ("show-unreliable,u", bool_switch(&_showUnreliableDetections), "Show the unreliable tags (marker id = -1)")
 #ifdef CCTAG_WITH_CUDA
 		("sync", bool_switch(&_switchSync), "CUDA debug option, run all CUDA ops synchronously")
 		("use-cuda", bool_switch(&_useCuda), "Select GPU code instead of CPU code")
@@ -83,6 +87,10 @@ void CmdLine::print( const char* const argv0 ) const
          << "    --bank      " << _cctagBankFilename << std::endl
          << "    --params    " << _paramsFilename << std::endl
          << "    --output    " << _outputFolderName << std::endl;
+    if(_saveDetectedImage)
+        std::cout << "    --save-detected-image" << std::endl;
+    if(_showUnreliableDetections)
+        std::cout << "    --show-unreliable" << std::endl;
 #ifdef CCTAG_WITH_CUDA
 	std::cout << "    --parallel " << _parallel << std::endl;
     if( _switchSync )

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -46,7 +46,11 @@ CmdLine::CmdLine( )
 		("bank,b", value<std::string>(&_cctagBankFilename)->default_value(_cctagBankFilename), "Path to a bank parameter file, e.g. 4Crowns/ids.txt")
 		("params,p", value<std::string>(&_paramsFilename)->default_value(_paramsFilename), "Path to configuration XML file")
 		("output,o", value<std::string>(&_outputFolderName)->default_value(_outputFolderName), "Output folder name")
-                ("save-detected-image,s", bool_switch(&_saveDetectedImage), "Save an image with the graphical overlay of the detected tags")
+                ("save-detected-image,s", bool_switch(&_saveDetectedImage), "Save an image with the graphical overlay of the detected tags. "
+                     "For single images the saved images will have a '_detected' suffix and it will be placed either in "
+                     "the current directory or in the directory given by --output. For videos a file named #####.png "
+                     "will be saved instead with the #s representing the zero-padded frame number, either in the current directory "
+                     "or in the directory given by --output.")
                 ("show-unreliable,u", bool_switch(&_showUnreliableDetections), "Show the unreliable tags (marker id = -1)")
 #ifdef CCTAG_WITH_CUDA
 		("sync", bool_switch(&_switchSync), "CUDA debug option, run all CUDA ops synchronously")

--- a/src/applications/detection/CmdLine.cpp
+++ b/src/applications/detection/CmdLine.cpp
@@ -29,13 +29,16 @@ CmdLine::CmdLine( )
     , _useCuda( false )
     , _parallel( 1 )
 #endif
-	, _allParams("Program for detecting CCTags in images or in a video")
+	, _allParams("Program for detecting CCTags in one image, in a directory or in a video\n"
+               "For each image or video frame it detects the markers and it shows the image with a graphical overlay"
+               "showing the center of the tag, its ID and the outer ellipse")
 { 
 	using namespace boost::program_options;
 
 	options_description required("Required input parameters");
 	required.add_options()
-		("input,i", value<std::string>(&_filename)->required(), "Path to an image (JPG, PNG) or video (avi, mov) or camera index for live capture (0, 1...)")
+		("input,i", value<std::string>(&_filename)->required(), "Path to an image (JPG, PNG) or video (avi, mov) "
+                     "or camera index for live capture (0, 1...) or to a directory containing the images to process")
 		("nbrings,n", value<std::size_t>(&_nRings)->required(), "Number of rings of the CCTags to detect");
 
 	options_description optional("Optional parameters");

--- a/src/applications/detection/CmdLine.hpp
+++ b/src/applications/detection/CmdLine.hpp
@@ -7,38 +7,38 @@
  */
 #pragma once
 
-#include <string>
 #include <boost/program_options.hpp>
+
+#include <string>
 
 namespace cctag {
 
 class CmdLine
 {
-public:
-    std::string _filename;
-    std::string _cctagBankFilename;
-    std::string _paramsFilename;
-    std::size_t _nRings;
-    std::string _outputFolderName;
-    bool _saveDetectedImage;
-    bool _showUnreliableDetections;
+  public:
+    std::string _filename{};
+    std::string _cctagBankFilename{};
+    std::string _paramsFilename{};
+    std::size_t _nRings{3};
+    std::string _outputFolderName{};
+    bool _saveDetectedImage{false};
+    bool _showUnreliableDetections{false};
 #ifdef CCTAG_WITH_CUDA
-    bool        _switchSync;
-    std::string _debugDir;
-    bool        _useCuda;
-    int         _parallel;
+    bool _switchSync{false};
+    std::string _debugDir{};
+    bool _useCuda{false};
+    int _parallel{1};
 #endif
 
-    CmdLine( );
+    CmdLine();
 
-    bool parse( int argc, char* argv[] );
-    void print( const char* const argv0 ) const;
+    bool parse(int argc, char* argv[]);
+    void print(const char* const argv0) const;
 
-    void usage( const char* const argv0 ) const;
+    void usage(const char* const argv0) const;
 
-private:
-	boost::program_options::options_description _allParams;
+  private:
+    boost::program_options::options_description _allParams;
 };
 
 }
-

--- a/src/applications/detection/CmdLine.hpp
+++ b/src/applications/detection/CmdLine.hpp
@@ -30,9 +30,9 @@ public:
     CmdLine( );
 
     bool parse( int argc, char* argv[] );
-    void print( const char* const argv0 );
+    void print( const char* const argv0 ) const;
 
-    void usage( const char* const argv0 );
+    void usage( const char* const argv0 ) const;
 
 private:
 	boost::program_options::options_description _allParams;

--- a/src/applications/detection/CmdLine.hpp
+++ b/src/applications/detection/CmdLine.hpp
@@ -20,6 +20,8 @@ public:
     std::string _paramsFilename;
     std::size_t _nRings;
     std::string _outputFolderName;
+    bool _saveDetectedImage;
+    bool _showUnreliableDetections;
 #ifdef CCTAG_WITH_CUDA
     bool        _switchSync;
     std::string _debugDir;

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -355,6 +355,10 @@ int main(int argc, char** argv)
     cv::Mat graySrc;
     cv::cvtColor(src, graySrc, CV_BGR2GRAY);
 
+      const std::string windowName = "Detection result";
+      cv::namedWindow(windowName, cv::WINDOW_NORMAL);
+      const int delay = -1;
+
     const int pipeId = 0;
     boost::ptr_list<CCTag> markers;
 #ifdef PRINT_TO_CERR
@@ -362,6 +366,23 @@ int main(int argc, char** argv)
 #else // PRINT_TO_CERR
     detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
 #endif // PRINT_TO_CERR
+
+      // if the original image is b/w convert it to BGRA so we can draw colors
+      if(src.channels() == 1)
+          cv::cvtColor(graySrc, src, cv::COLOR_GRAY2BGRA);
+
+      drawMarkers(markers, src, cmdline._showUnreliableDetections);
+      cv::imshow(windowName, src);
+      cv::waitKey(delay);
+      if(cmdline._saveDetectedImage)
+      {
+          auto saveFilename = bfs::path(myPath.filename().stem().string() + "_detected" + ext);
+          if(!cmdline._outputFolderName.empty())
+          {
+              saveFilename = bfs::path(cmdline._outputFolderName) / saveFilename;
+          }
+          cv::imwrite(saveFilename.string(), src);
+      }
   }
 #endif // USE_DEVIL
   else if(ext == ".avi" || ext == ".mov" || useCamera)
@@ -428,7 +449,7 @@ int main(int argc, char** argv)
       if(frame.channels() == 1)
         cv::cvtColor(imgGray, frame, cv::COLOR_GRAY2BGRA);
       
-      drawMarkers(markers, frame);
+      drawMarkers(markers, frame, cmdline._showUnreliableDetections);
       cv::imshow(windowName, frame);
       if( cv::waitKey(delay) == 27 ) break;
       char key = (char) cv::waitKey(delay);

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -67,7 +67,7 @@ bool isInteger(std::string &s)
  * @param[in] markers The list of markers to draw.
  * @param[out] image The image in which to draw the markers.
  */
-void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
+void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image, bool showUnreliable = true)
 {
   for(const cctag::CCTag & marker : markers)
   {
@@ -84,13 +84,12 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
         cv::ellipse(image , center,  cv::Size(rescaledOuterEllipse.a(), rescaledOuterEllipse.b()),
         rescaledOuterEllipse.angle()*180/boost::math::constants::pi<double>(), 0, 360, color, 3);
     }
-    else
+    else if(showUnreliable)
     {
       const cv::Scalar color = cv::Scalar(0, 0, 255 , 255);
       cv::circle(image, center, radius, color, 2);
       cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
     }
-
   }
 }
 

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -451,6 +451,17 @@ int main(int argc, char** argv)
       
       drawMarkers(markers, frame, cmdline._showUnreliableDetections);
       cv::imshow(windowName, frame);
+
+        if(cmdline._saveDetectedImage)
+        {
+            auto saveFilename = bfs::path(outputFileName+".png");
+            if(!cmdline._outputFolderName.empty())
+            {
+                saveFilename = bfs::path(cmdline._outputFolderName) / saveFilename;
+            }
+            cv::imwrite(saveFilename.string(), frame);
+        }
+
       if( cv::waitKey(delay) == 27 ) break;
       char key = (char) cv::waitKey(delay);
       // stop capturing by pressing ESC

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -78,7 +78,6 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image, bool sho
     {
       const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
         const auto rescaledOuterEllipse = marker.rescaledOuterEllipse();
-        std::cout << "a " << rescaledOuterEllipse.a() << " b " << rescaledOuterEllipse.b() << " angle " << rescaledOuterEllipse.angle() << std::endl;
       cv::circle(image, center, radius, color, 3);
       cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
         cv::ellipse(image , center,  cv::Size(rescaledOuterEllipse.a(), rescaledOuterEllipse.b()),

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -77,8 +77,12 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image)
     if(marker.getStatus() == status::id_reliable)
     {
       const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
+        const auto rescaledOuterEllipse = marker.rescaledOuterEllipse();
+        std::cout << "a " << rescaledOuterEllipse.a() << " b " << rescaledOuterEllipse.b() << " angle " << rescaledOuterEllipse.angle() << std::endl;
       cv::circle(image, center, radius, color, 3);
       cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
+        cv::ellipse(image , center,  cv::Size(rescaledOuterEllipse.a(), rescaledOuterEllipse.b()),
+        rescaledOuterEllipse.angle()*180/boost::math::constants::pi<double>(), 0, 360, color, 3);
     }
     else
     {

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -78,6 +78,7 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image, bool sho
     {
       const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
         const auto rescaledOuterEllipse = marker.rescaledOuterEllipse();
+
       cv::circle(image, center, radius, color, 3);
       cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
         cv::ellipse(image , center,  cv::Size(rescaledOuterEllipse.a(), rescaledOuterEllipse.b()),
@@ -519,7 +520,7 @@ int main(int argc, char** argv)
 #ifdef PRINT_TO_CERR
           detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, std::cerr, inputImageFile.stem().string());
 #else
-          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, outputFile, fileInFolder.second.stem().string());
+          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, outputFile, inputImageFile.second.stem().string());
 #endif
             // if the original image is b/w convert it to BGRA so we can draw colors
             if(src.channels() == 1)

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -5,42 +5,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "CmdLine.hpp"
+#include "cctag/Detection.hpp"
+#include "cctag/utils/Exceptions.hpp"
 #include "cctag/utils/FileDebug.hpp"
 #include "cctag/utils/VisualDebug.hpp"
-#include "cctag/utils/Exceptions.hpp"
-#include "cctag/Detection.hpp"
-#include "CmdLine.hpp"
 
 #ifdef CCTAG_WITH_CUDA
-#include "cctag/cuda/device_prop.hpp"
 #include "cctag/cuda/debug_macros.hpp"
+#include "cctag/cuda/device_prop.hpp"
 #endif // CCTAG_WITH_CUDA
 
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/timer/timer.hpp>
-#include <boost/exception/all.hpp>
-#include <boost/ptr_container/ptr_list.hpp>
-#include <boost/archive/xml_oarchive.hpp>
-#include <boost/archive/xml_iarchive.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
-
-#include <opencv2/videoio.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/exception/all.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/convenience.hpp>
+#include <boost/ptr_container/ptr_list.hpp>
+#include <boost/timer/timer.hpp>
 #include <opencv2/core/core.hpp>
-#include <opencv2/opencv.hpp>
 #include <opencv2/imgproc/types_c.h>
+#include <opencv2/opencv.hpp>
+#include <opencv2/videoio.hpp>
 
 #ifdef USE_DEVIL
 #include <devil_cpp_wrapper.hpp>
 #endif
 
-#include <sstream>
-#include <iostream>
-#include <string>
-#include <fstream>
-#include <exception>
-
 #include <tbb/tbb.h>
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
 
 #define PRINT_TO_CERR
 
@@ -50,52 +49,55 @@ namespace bfs = boost::filesystem;
 
 /**
  * @brief Check if a string is an integer number.
- * 
+ *
  * @param[in] s The string to check.
  * @return Return true if the string is an integer number
  */
-bool isInteger(std::string &s)
-{
-  return (s.size() == 1 && std::isdigit(s[0]));
-}
+bool isInteger(std::string& s) { return (s.size() == 1 && std::isdigit(s[0])); }
 
 /**
  * @brief Draw the detected marker int the given image. The markers are drawn as a
- * circle centered in the center of the marker and with its id. It draws the 
+ * circle centered in the center of the marker and with its id. It draws the
  * well identified markers in green, the unknown / badly detected markers in red.
- * 
+ *
  * @param[in] markers The list of markers to draw.
  * @param[out] image The image in which to draw the markers.
  */
-void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image, bool showUnreliable = true)
+void drawMarkers(const boost::ptr_list<CCTag>& markers, cv::Mat& image, bool showUnreliable = true)
 {
-  for(const cctag::CCTag & marker : markers)
-  {
-    const cv::Point center = cv::Point(marker.x(), marker.y());
-    const int radius = 10;
-    const int fontSize = 3;
-    if(marker.getStatus() == status::id_reliable)
+    for(const cctag::CCTag& marker : markers)
     {
-      const cv::Scalar color = cv::Scalar(0, 255, 0 , 255);
-        const auto rescaledOuterEllipse = marker.rescaledOuterEllipse();
+        const cv::Point center = cv::Point(marker.x(), marker.y());
+        const int radius = 10;
+        const int fontSize = 3;
+        if(marker.getStatus() == status::id_reliable)
+        {
+            const cv::Scalar color = cv::Scalar(0, 255, 0, 255);
+            const auto rescaledOuterEllipse = marker.rescaledOuterEllipse();
 
-      cv::circle(image, center, radius, color, 3);
-      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
-        cv::ellipse(image , center,  cv::Size(rescaledOuterEllipse.a(), rescaledOuterEllipse.b()),
-        rescaledOuterEllipse.angle()*180/boost::math::constants::pi<double>(), 0, 360, color, 3);
+            cv::circle(image, center, radius, color, 3);
+            cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
+            cv::ellipse(image,
+                        center,
+                        cv::Size(rescaledOuterEllipse.a(), rescaledOuterEllipse.b()),
+                        rescaledOuterEllipse.angle() * 180 / boost::math::constants::pi<double>(),
+                        0,
+                        360,
+                        color,
+                        3);
+        }
+        else if(showUnreliable)
+        {
+            const cv::Scalar color = cv::Scalar(0, 0, 255, 255);
+            cv::circle(image, center, radius, color, 2);
+            cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
+        }
     }
-    else if(showUnreliable)
-    {
-      const cv::Scalar color = cv::Scalar(0, 0, 255 , 255);
-      cv::circle(image, center, radius, color, 2);
-      cv::putText(image, std::to_string(marker.id()), center, cv::FONT_HERSHEY_SIMPLEX, fontSize, color, 3);
-    }
-  }
 }
 
 /**
  * @brief Extract the cctag from an image.
- * 
+ *
  * @param[in] frameId The number of the frame.
  * @param[in] pipeId The pipe id (used for multiple streams).
  * @param[in] src The image to process.
@@ -103,77 +105,76 @@ void drawMarkers(const boost::ptr_list<CCTag> &markers, cv::Mat &image, bool sho
  * @param[in] bank The marker bank.
  * @param[out] markers The list of detected markers.
  * @param[out] outStream The output stream on which to write debug information.
- * @param[out] debugFileName The filename for the image to save with the detected 
+ * @param[out] debugFileName The filename for the image to save with the detected
  * markers.
  */
 void detection(std::size_t frameId,
                int pipeId,
-               const cv::Mat & src,
-               const cctag::Parameters & params,
-               const cctag::CCTagMarkersBank & bank,
-               boost::ptr_list<CCTag> &markers,
-               std::ostream & outStream,
+               const cv::Mat& src,
+               const cctag::Parameters& params,
+               const cctag::CCTagMarkersBank& bank,
+               boost::ptr_list<CCTag>& markers,
+               std::ostream& outStream,
                std::string debugFileName = "")
 {
-
-  if(debugFileName.empty())
-  {
-    debugFileName = "00000";
-  }
-
-  // Process markers detection
-  boost::timer::cpu_timer t;
-
-  CCTagVisualDebug::instance().initBackgroundImage(src);
-  CCTagVisualDebug::instance().setImageFileName(debugFileName);
-  CCTagFileDebug::instance().setPath(CCTagVisualDebug::instance().getPath());
-
-  static cctag::logtime::Mgmt* durations = nullptr;
-
-  //Call the main CCTag detection function
-  cctagDetection(markers, pipeId, frameId, src, params, bank, true, durations);
-
-  if(durations)
-  {
-    durations->print(std::cerr);
-  }
-
-  CCTagFileDebug::instance().outPutAllSessions();
-  CCTagFileDebug::instance().clearSessions();
-  CCTagVisualDebug::instance().outPutAllSessions();
-  CCTagVisualDebug::instance().clearSessions();
-
-  std::cout << "Total time: " << t.format() << std::endl;
-  CCTAG_COUT_NOENDL("Id : ");
-
-  std::size_t counter = 0;
-  std::size_t nMarkers = 0;
-  outStream << "#frame " << frameId << '\n';
-  outStream << "Detected " << markers.size() << " candidates" << '\n';
-
-  for(const cctag::CCTag & marker : markers)
-  {
-    outStream << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
-    ++counter;
-    if(marker.getStatus() == status::id_reliable)
-      ++nMarkers;
-  }
-  
-  counter = 0;
-  for(const cctag::CCTag & marker : markers)
-  {
-    if(counter == 0)
+    if(debugFileName.empty())
     {
-      CCTAG_COUT_NOENDL(marker.id() + 1);
+        debugFileName = "00000";
     }
-    else
-    {
-      CCTAG_COUT_NOENDL(", " << marker.id() + 1);
-    }
-    ++counter;
-  }
 
-  std::cout << std::endl << nMarkers << " markers detected and identified" << std::endl;
+    // Process markers detection
+    boost::timer::cpu_timer t;
+
+    CCTagVisualDebug::instance().initBackgroundImage(src);
+    CCTagVisualDebug::instance().setImageFileName(debugFileName);
+    CCTagFileDebug::instance().setPath(CCTagVisualDebug::instance().getPath());
+
+    static cctag::logtime::Mgmt* durations = nullptr;
+
+    // Call the main CCTag detection function
+    cctagDetection(markers, pipeId, frameId, src, params, bank, true, durations);
+
+    if(durations)
+    {
+        durations->print(std::cerr);
+    }
+
+    CCTagFileDebug::instance().outPutAllSessions();
+    CCTagFileDebug::instance().clearSessions();
+    CCTagVisualDebug::instance().outPutAllSessions();
+    CCTagVisualDebug::instance().clearSessions();
+
+    std::cout << "Total time: " << t.format() << std::endl;
+    CCTAG_COUT_NOENDL("Id : ");
+
+    std::size_t counter = 0;
+    std::size_t nMarkers = 0;
+    outStream << "#frame " << frameId << '\n';
+    outStream << "Detected " << markers.size() << " candidates" << '\n';
+
+    for(const cctag::CCTag& marker : markers)
+    {
+        outStream << marker.x() << " " << marker.y() << " " << marker.id() << " " << marker.getStatus() << '\n';
+        ++counter;
+        if(marker.getStatus() == status::id_reliable)
+            ++nMarkers;
+    }
+
+    counter = 0;
+    for(const cctag::CCTag& marker : markers)
+    {
+        if(counter == 0)
+        {
+            CCTAG_COUT_NOENDL(marker.id() + 1);
+        }
+        else
+        {
+            CCTAG_COUT_NOENDL(", " << marker.id() + 1);
+        }
+        ++counter;
+    }
+
+    std::cout << std::endl << nMarkers << " markers detected and identified" << std::endl;
 }
 
 /*************************************************************/
@@ -182,373 +183,370 @@ void detection(std::size_t frameId,
 /*************************************************************/
 int main(int argc, char** argv)
 {
-  CmdLine cmdline;
+    CmdLine cmdline;
 
-  const std::string detectedSuffix{"_detected"};
+    const std::string detectedSuffix{"_detected"};
 
-  if(!cmdline.parse(argc, argv))
-  {
-    cmdline.usage(argv[0]);
-    return EXIT_FAILURE;
-  }
-
-  cmdline.print(argv[0]);
-  
-  bool useCamera = false;
-
-  // Check input path
-  if(!cmdline._filename.empty())
-  {
-    if(isInteger(cmdline._filename))
+    if(!cmdline.parse(argc, argv))
     {
-      useCamera = true;
+        cmdline.usage(argv[0]);
+        return EXIT_FAILURE;
     }
-    else if(!bfs::exists(cmdline._filename))
+
+    cmdline.print(argv[0]);
+
+    bool useCamera = false;
+
+    // Check input path
+    if(!cmdline._filename.empty())
     {
-      std::cerr << std::endl
-              << "The input file \"" << cmdline._filename << "\" is missing" << std::endl;
-      return EXIT_FAILURE;
+        if(isInteger(cmdline._filename))
+        {
+            useCamera = true;
+        }
+        else if(!bfs::exists(cmdline._filename))
+        {
+            std::cerr << std::endl << "The input file \"" << cmdline._filename << "\" is missing" << std::endl;
+            return EXIT_FAILURE;
+        }
     }
-  }
-  else
-  {
-    std::cerr << std::endl
-            << "An input file is required" << std::endl;
-    cmdline.usage(argv[0]);
-    return EXIT_FAILURE;
-  }
+    else
+    {
+        std::cerr << std::endl << "An input file is required" << std::endl;
+        cmdline.usage(argv[0]);
+        return EXIT_FAILURE;
+    }
 
 #ifdef CCTAG_WITH_CUDA
-  cctag::pop_cuda_only_sync_calls(cmdline._switchSync);
+    cctag::pop_cuda_only_sync_calls(cmdline._switchSync);
 #endif
 
-  // Check the (optional) parameters path
-  const std::size_t nCrowns = cmdline._nRings;
-  cctag::Parameters params(nCrowns);
+    // Check the (optional) parameters path
+    const std::size_t nCrowns = cmdline._nRings;
+    cctag::Parameters params(nCrowns);
 
-  if(!cmdline._paramsFilename.empty())
-  {
-    if(!bfs::exists(cmdline._paramsFilename))
+    if(!cmdline._paramsFilename.empty())
     {
-      std::cerr << std::endl
-              << "The input file \"" << cmdline._paramsFilename << "\" is missing" << std::endl;
-      return EXIT_FAILURE;
+        if(!bfs::exists(cmdline._paramsFilename))
+        {
+            std::cerr << std::endl << "The input file \"" << cmdline._paramsFilename << "\" is missing" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        // Read the parameter file provided by the user
+        std::ifstream ifs(cmdline._paramsFilename);
+        boost::archive::xml_iarchive ia(ifs);
+        ia >> boost::serialization::make_nvp("CCTagsParams", params);
+        CCTAG_COUT(params._nCrowns);
+        CCTAG_COUT(nCrowns);
+        if(nCrowns != params._nCrowns)
+        {
+            std::cerr << std::endl
+                      << "The number of rings is inconsistent between the parameter file (" << params._nCrowns
+                      << ") and the command line (" << nCrowns << ")" << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+    else
+    {
+        // Use the default parameters and save them in defaultParameters.xml
+        cmdline._paramsFilename = "defaultParameters.xml";
+        std::ofstream ofs(cmdline._paramsFilename);
+        boost::archive::xml_oarchive oa(ofs);
+        oa << boost::serialization::make_nvp("CCTagsParams", params);
+        CCTAG_COUT("Parameter file not provided. Default parameters are used.");
     }
 
-    // Read the parameter file provided by the user
-    std::ifstream ifs(cmdline._paramsFilename);
-    boost::archive::xml_iarchive ia(ifs);
-    ia >> boost::serialization::make_nvp("CCTagsParams", params);
-    CCTAG_COUT(params._nCrowns);
-    CCTAG_COUT(nCrowns);
-    if(nCrowns != params._nCrowns)
+    CCTagMarkersBank bank(params._nCrowns);
+    if(!cmdline._cctagBankFilename.empty())
     {
-      std::cerr << std::endl
-              << "The number of rings is inconsistent between the parameter file (" 
-              << params._nCrowns << ") and the command line (" 
-              << nCrowns << ")" << std::endl;
-      return EXIT_FAILURE;
+        bank = CCTagMarkersBank(cmdline._cctagBankFilename);
     }
-  }
-  else
-  {
-    // Use the default parameters and save them in defaultParameters.xml
-    cmdline._paramsFilename = "defaultParameters.xml";
-    std::ofstream ofs(cmdline._paramsFilename);
-    boost::archive::xml_oarchive oa(ofs);
-    oa << boost::serialization::make_nvp("CCTagsParams", params);
-    CCTAG_COUT("Parameter file not provided. Default parameters are used.");
-  }
-
-  CCTagMarkersBank bank(params._nCrowns);
-  if(!cmdline._cctagBankFilename.empty())
-  {
-    bank = CCTagMarkersBank(cmdline._cctagBankFilename);
-  }
 
 #ifdef CCTAG_WITH_CUDA
-  if(cmdline._useCuda)
-  {
-    params.setUseCuda(true);
-  }
-  else
-  {
-    params.setUseCuda(false);
-  }
+    if(cmdline._useCuda)
+    {
+        params.setUseCuda(true);
+    }
+    else
+    {
+        params.setUseCuda(false);
+    }
 
-  if(!cmdline._debugDir.empty())
-  {
-    params.setDebugDir(cmdline._debugDir);
-  }
+    if(!cmdline._debugDir.empty())
+    {
+        params.setDebugDir(cmdline._debugDir);
+    }
 
-  cctag::device_prop_t deviceInfo(false);
+    cctag::device_prop_t deviceInfo(false);
 #endif // CCTAG_WITH_CUDA
 
-  bfs::path myPath(bfs::absolute(cmdline._filename));
-  std::string ext(myPath.extension().string());
-  boost::algorithm::to_lower(ext);
+    bfs::path myPath(bfs::absolute(cmdline._filename));
+    std::string ext(myPath.extension().string());
+    boost::algorithm::to_lower(ext);
 
-  const bfs::path parentPath(myPath.parent_path());
-  std::string outputFileName;
-  if(!bfs::is_directory(myPath))
-  {
-    CCTagVisualDebug::instance().initializeFolders(parentPath, cmdline._outputFolderName, params._nCrowns);
-    outputFileName = parentPath.string() + "/" + cmdline._outputFolderName + "/cctag" + std::to_string(nCrowns) + "CC.out";
-  }
-  else
-  {
-    CCTagVisualDebug::instance().initializeFolders(myPath, cmdline._outputFolderName, params._nCrowns);
-    outputFileName = myPath.string() + "/" + cmdline._outputFolderName + "/cctag" + std::to_string(nCrowns) + "CC.out";
-  }
-  std::ofstream outputFile;
-  outputFile.open(outputFileName);
+    const bfs::path parentPath(myPath.parent_path());
+    std::string outputFileName;
+    if(!bfs::is_directory(myPath))
+    {
+        CCTagVisualDebug::instance().initializeFolders(parentPath, cmdline._outputFolderName, params._nCrowns);
+        outputFileName =
+          parentPath.string() + "/" + cmdline._outputFolderName + "/cctag" + std::to_string(nCrowns) + "CC.out";
+    }
+    else
+    {
+        CCTagVisualDebug::instance().initializeFolders(myPath, cmdline._outputFolderName, params._nCrowns);
+        outputFileName =
+          myPath.string() + "/" + cmdline._outputFolderName + "/cctag" + std::to_string(nCrowns) + "CC.out";
+    }
+    std::ofstream outputFile;
+    outputFile.open(outputFileName);
 
 #if USE_DEVIL
-  if( (ext == ".bmp") ||
-      (ext == ".gif") ||
-      (ext == ".jpg") ||
-      (ext == ".lbm") ||
-      (ext == ".pbm") ||
-      (ext == ".pgm") ||
-      (ext == ".png") ||
-      (ext == ".ppm") ||
-      (ext == ".tga") ||
-      (ext == ".tif") )
-  {
-    std::cout << "******************* Image mode **********************" << std::endl;
-    POP_INFO("looking at image " << myPath.string());
-    ilImage img;
-    if( img.Load( cmdline._filename.c_str() ) == false )
+    if((ext == ".bmp") || (ext == ".gif") || (ext == ".jpg") || (ext == ".lbm") || (ext == ".pbm") || (ext == ".pgm") ||
+       (ext == ".png") || (ext == ".ppm") || (ext == ".tga") || (ext == ".tif"))
     {
-      std::cerr << "Could not load image " << cmdline._filename << std::endl;
-      return 0;
-    }
-    if( img.Convert( IL_LUMINANCE ) == false )
-    {
-      std::cerr << "Failed converting image " << cmdline._filename << " to unsigned greyscale image" << std::endl;
-      exit( -1 );
-    }
-    int w = img.Width();
-    int h = img.Height();
-    std::cout << "Loading " << w << " x " << h << " image " << cmdline._filename << std::endl;
-    unsigned char* image_data = img.GetData();
-    cv::Mat graySrc = cv::Mat( h, w, CV_8U, image_data );
+        std::cout << "******************* Image mode **********************" << std::endl;
+        POP_INFO("looking at image " << myPath.string());
+        ilImage img;
+        if(img.Load(cmdline._filename.c_str()) == false)
+        {
+            std::cerr << "Could not load image " << cmdline._filename << std::endl;
+            return 0;
+        }
+        if(img.Convert(IL_LUMINANCE) == false)
+        {
+            std::cerr << "Failed converting image " << cmdline._filename << " to unsigned greyscale image" << std::endl;
+            exit(-1);
+        }
+        int w = img.Width();
+        int h = img.Height();
+        std::cout << "Loading " << w << " x " << h << " image " << cmdline._filename << std::endl;
+        unsigned char* image_data = img.GetData();
+        cv::Mat graySrc = cv::Mat(h, w, CV_8U, image_data);
 
-    imwrite( "ballo.jpg", graySrc );
+        imwrite("ballo.jpg", graySrc);
 
-    const int pipeId = 0;
-    boost::ptr_list<CCTag> markers;
+        const int pipeId = 0;
+        boost::ptr_list<CCTag> markers;
 #ifdef PRINT_TO_CERR
-    detection(0, pipeId, graySrc, params, bank, markers, std::cerr, myPath.stem().string());
-#else // PRINT_TO_CERR
-    detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
+        detection(0, pipeId, graySrc, params, bank, markers, std::cerr, myPath.stem().string());
+#else  // PRINT_TO_CERR
+        detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
 #endif // PRINT_TO_CERR
-  }
+    }
 #else // USE_DEVIL
-  if((ext == ".png") || (ext == ".jpg") || (ext == ".tif") || (ext == ".tiff"))
-  {
+    if((ext == ".png") || (ext == ".jpg") || (ext == ".tif") || (ext == ".tiff"))
+    {
+        std::cout << "******************* Image mode **********************" << std::endl;
 
-    std::cout << "******************* Image mode **********************" << std::endl;
+        POP_INFO("looking at image " << myPath.string());
 
-    POP_INFO("looking at image " << myPath.string());
+        // Gray scale conversion
+        cv::Mat src = cv::imread(cmdline._filename);
+        cv::Mat graySrc;
+        cv::cvtColor(src, graySrc, CV_BGR2GRAY);
 
-    // Gray scale conversion
-    cv::Mat src = cv::imread(cmdline._filename);
-    cv::Mat graySrc;
-    cv::cvtColor(src, graySrc, CV_BGR2GRAY);
+        const std::string windowName = "Detection result";
+        cv::namedWindow(windowName, cv::WINDOW_NORMAL);
+        const int delay = -1;
 
-      const std::string windowName = "Detection result";
-      cv::namedWindow(windowName, cv::WINDOW_NORMAL);
-      const int delay = -1;
-
-    const int pipeId = 0;
-    boost::ptr_list<CCTag> markers;
+        const int pipeId = 0;
+        boost::ptr_list<CCTag> markers;
 #ifdef PRINT_TO_CERR
-    detection(0, pipeId, graySrc, params, bank, markers, std::cerr, myPath.stem().string());
-#else // PRINT_TO_CERR
-    detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
+        detection(0, pipeId, graySrc, params, bank, markers, std::cerr, myPath.stem().string());
+#else  // PRINT_TO_CERR
+        detection(0, pipeId, graySrc, params, bank, markers, outputFile, myPath.stem().string());
 #endif // PRINT_TO_CERR
 
-      // if the original image is b/w convert it to BGRA so we can draw colors
-      if(src.channels() == 1)
-          cv::cvtColor(graySrc, src, cv::COLOR_GRAY2BGRA);
+        // if the original image is b/w convert it to BGRA so we can draw colors
+        if(src.channels() == 1)
+            cv::cvtColor(graySrc, src, cv::COLOR_GRAY2BGRA);
 
-      drawMarkers(markers, src, cmdline._showUnreliableDetections);
-      cv::imshow(windowName, src);
-      cv::waitKey(delay);
-      if(cmdline._saveDetectedImage)
-      {
-          auto saveFilename = bfs::path(myPath.filename().stem().string() + detectedSuffix + ext);
-          if(!cmdline._outputFolderName.empty())
-          {
-              saveFilename = bfs::path(cmdline._outputFolderName) / saveFilename;
-          }
-          cv::imwrite(saveFilename.string(), src);
-      }
-  }
-#endif // USE_DEVIL
-  else if(ext == ".avi" || ext == ".mov" || useCamera)
-  {
-    CCTAG_COUT("*** Video mode ***");
-    POP_INFO("looking at video " << myPath.string());
-
-    // open video and check
-    cv::VideoCapture video;
-    if(useCamera)
-      video.open(std::atoi(cmdline._filename.c_str()));
-    else
-      video.open(cmdline._filename);
-    
-    if(!video.isOpened())
-    {
-      CCTAG_COUT("Unable to open the video : " << cmdline._filename);
-      return EXIT_FAILURE;
-    }
-
-    const std::string windowName = "Detection result";
-    cv::namedWindow(windowName, cv::WINDOW_NORMAL);
-
-    std::cerr << "Starting to read video frames" << std::endl;
-    std::size_t frameId = 0;
-    
-    // time to wait in milliseconds for keyboard input, used to switch from
-    // live to debug mode
-    int delay = 10;
-
-    while(true)
-    {
-      cv::Mat frame;
-      video >> frame;
-      if(frame.empty())
-        break;
-      
-      cv::Mat imgGray;
-
-      if(frame.channels() == 3 || frame.channels() == 4)
-        cv::cvtColor(frame, imgGray, cv::COLOR_BGR2GRAY);
-      else
-        frame.copyTo(imgGray);
-
-      // Set the output folder
-      std::stringstream outFileName;
-      outFileName << std::setfill('0') << std::setw(5) << frameId;
-      
-      boost::ptr_list<CCTag> markers;
-
-      // Invert the image for the projection scenario
-      //cv::Mat imgGrayInverted;
-      //bitwise_not ( imgGray, imgGrayInverted );
-
-      // Call the CCTag detection
-      const int pipeId = 0;
-#ifdef PRINT_TO_CERR
-      detection(frameId, pipeId, imgGray, params, bank, markers, std::cerr, outFileName.str());
-#else
-      detection(frameId, pipeId, imgGray, params, bank, markers, outputFile, outFileName.str());
-#endif
-      
-      // if the original image is b/w convert it to BGRA so we can draw colors
-      if(frame.channels() == 1)
-        cv::cvtColor(imgGray, frame, cv::COLOR_GRAY2BGRA);
-      
-      drawMarkers(markers, frame, cmdline._showUnreliableDetections);
-      cv::imshow(windowName, frame);
-
+        drawMarkers(markers, src, cmdline._showUnreliableDetections);
+        cv::imshow(windowName, src);
+        cv::waitKey(delay);
         if(cmdline._saveDetectedImage)
         {
-            auto saveFilename = bfs::path(outputFileName+".png");
+            auto saveFilename = bfs::path(myPath.filename().stem().string() + detectedSuffix + ext);
             if(!cmdline._outputFolderName.empty())
             {
                 saveFilename = bfs::path(cmdline._outputFolderName) / saveFilename;
             }
-            cv::imwrite(saveFilename.string(), frame);
+            cv::imwrite(saveFilename.string(), src);
+        }
+    }
+#endif // USE_DEVIL
+    else if(ext == ".avi" || ext == ".mov" || useCamera)
+    {
+        CCTAG_COUT("*** Video mode ***");
+        POP_INFO("looking at video " << myPath.string());
+
+        // open video and check
+        cv::VideoCapture video;
+        if(useCamera)
+            video.open(std::atoi(cmdline._filename.c_str()));
+        else
+            video.open(cmdline._filename);
+
+        if(!video.isOpened())
+        {
+            CCTAG_COUT("Unable to open the video : " << cmdline._filename);
+            return EXIT_FAILURE;
         }
 
-      if( cv::waitKey(delay) == 27 ) break;
-      char key = (char) cv::waitKey(delay);
-      // stop capturing by pressing ESC
-      if(key == 27) 
-        break;
-      if(key == 'l' || key == 'L')
-        delay = 10;
-      // delay = 0 will wait for a key to be pressed
-      if(key == 'd' || key == 'D')
-        delay = 0;
-      
-      ++frameId;
-    }
+        const std::string windowName = "Detection result";
+        cv::namedWindow(windowName, cv::WINDOW_NORMAL);
 
-  }
-  else if(bfs::is_directory(myPath))
-  {
-    CCTAG_COUT("*** Image sequence mode ***");
+        std::cerr << "Starting to read video frames" << std::endl;
+        std::size_t frameId = 0;
 
-    std::vector<bfs::path> vFileInFolder;
+        // time to wait in milliseconds for keyboard input, used to switch from
+        // live to debug mode
+        int delay = 10;
 
-    std::copy(bfs::directory_iterator(myPath), bfs::directory_iterator(), std::back_inserter(vFileInFolder)); // is directory_entry, which is
-    std::sort(vFileInFolder.begin(), vFileInFolder.end());
-
-    std::size_t frameId = 0;
-
-    std::map<int, bfs::path> files[2];
-    for(const auto & fileInFolder : vFileInFolder)
-    {
-      files[frameId & 1].insert(std::pair<int, bfs::path>(frameId, fileInFolder));
-      frameId++;
-    }
-
-    tbb::parallel_for(0, 2, [&](size_t fileListIdx)
-    {
-      for(const auto & fileInFolder : files[fileListIdx])
-      {
-        const std::string subExt(bfs::extension(fileInFolder.second));
-
-        if((subExt == ".png") || (subExt == ".jpg") || (subExt == ".PNG") || (subExt == ".JPG"))
+        while(true)
         {
-            const auto inputImageFile = fileInFolder.second;
-          std::cerr << "Processing image " << inputImageFile << std::endl;
+            cv::Mat frame;
+            video >> frame;
+            if(frame.empty())
+                break;
 
-          cv::Mat src;
-          src = cv::imread(inputImageFile.string());
+            cv::Mat imgGray;
 
-          cv::Mat imgGray;
-          cv::cvtColor(src, imgGray, CV_BGR2GRAY);
+            if(frame.channels() == 3 || frame.channels() == 4)
+                cv::cvtColor(frame, imgGray, cv::COLOR_BGR2GRAY);
+            else
+                frame.copyTo(imgGray);
 
-          // Call the CCTag detection
-          int pipeId = (fileInFolder.first & 1);
-          boost::ptr_list<CCTag> markers;
+            // Set the output folder
+            std::stringstream outFileName;
+            outFileName << std::setfill('0') << std::setw(5) << frameId;
+
+            boost::ptr_list<CCTag> markers;
+
+            // Invert the image for the projection scenario
+            // cv::Mat imgGrayInverted;
+            // bitwise_not ( imgGray, imgGrayInverted );
+
+            // Call the CCTag detection
+            const int pipeId = 0;
 #ifdef PRINT_TO_CERR
-          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, std::cerr, inputImageFile.stem().string());
+            detection(frameId, pipeId, imgGray, params, bank, markers, std::cerr, outFileName.str());
 #else
-          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, outputFile, inputImageFile.second.stem().string());
+            detection(frameId, pipeId, imgGray, params, bank, markers, outputFile, outFileName.str());
 #endif
-            // if the original image is b/w convert it to BGRA so we can draw colors
-            if(src.channels() == 1)
-                cv::cvtColor(imgGray, src, cv::COLOR_GRAY2BGRA);
 
-            drawMarkers(markers, src, cmdline._showUnreliableDetections);
+            // if the original image is b/w convert it to BGRA so we can draw colors
+            if(frame.channels() == 1)
+                cv::cvtColor(imgGray, frame, cv::COLOR_GRAY2BGRA);
+
+            drawMarkers(markers, frame, cmdline._showUnreliableDetections);
+            cv::imshow(windowName, frame);
+
             if(cmdline._saveDetectedImage)
             {
-                // get the filename without extension and add the suffix
-                auto saveFilename = bfs::path(inputImageFile.filename().stem().string() + detectedSuffix + subExt);
+                auto saveFilename = bfs::path(outputFileName + ".png");
                 if(!cmdline._outputFolderName.empty())
                 {
                     saveFilename = bfs::path(cmdline._outputFolderName) / saveFilename;
                 }
-                cv::imwrite(saveFilename.string(), src);
+                cv::imwrite(saveFilename.string(), frame);
             }
 
-          std::cerr << "Done processing image " << fileInFolder.second.string() << std::endl;
-        }
-      }
-    });
-  }
-  else
-  {
-    std::cerr << "The input file format is not supported" << std::endl;
-    throw std::logic_error("Unrecognized input.");
-  }
-  outputFile.close();
-  return EXIT_SUCCESS;
-}
+            if(cv::waitKey(delay) == 27)
+                break;
+            char key = (char)cv::waitKey(delay);
+            // stop capturing by pressing ESC
+            if(key == 27)
+                break;
+            if(key == 'l' || key == 'L')
+                delay = 10;
+            // delay = 0 will wait for a key to be pressed
+            if(key == 'd' || key == 'D')
+                delay = 0;
 
+            ++frameId;
+        }
+    }
+    else if(bfs::is_directory(myPath))
+    {
+        CCTAG_COUT("*** Image sequence mode ***");
+
+        std::vector<bfs::path> vFileInFolder;
+
+        std::copy(bfs::directory_iterator(myPath),
+                  bfs::directory_iterator(),
+                  std::back_inserter(vFileInFolder)); // is directory_entry, which is
+        std::sort(vFileInFolder.begin(), vFileInFolder.end());
+
+        std::size_t frameId = 0;
+
+        std::map<int, bfs::path> files[2];
+        for(const auto& fileInFolder : vFileInFolder)
+        {
+            files[frameId & 1].insert(std::pair<int, bfs::path>(frameId, fileInFolder));
+            frameId++;
+        }
+
+        tbb::parallel_for(0, 2, [&](size_t fileListIdx) {
+            for(const auto& fileInFolder : files[fileListIdx])
+            {
+                const std::string subExt(bfs::extension(fileInFolder.second));
+
+                if((subExt == ".png") || (subExt == ".jpg") || (subExt == ".PNG") || (subExt == ".JPG"))
+                {
+                    const auto inputImageFile = fileInFolder.second;
+                    std::cerr << "Processing image " << inputImageFile << std::endl;
+
+                    cv::Mat src;
+                    src = cv::imread(inputImageFile.string());
+
+                    cv::Mat imgGray;
+                    cv::cvtColor(src, imgGray, CV_BGR2GRAY);
+
+                    // Call the CCTag detection
+                    int pipeId = (fileInFolder.first & 1);
+                    boost::ptr_list<CCTag> markers;
+#ifdef PRINT_TO_CERR
+                    detection(fileInFolder.first,
+                              pipeId,
+                              imgGray,
+                              params,
+                              bank,
+                              markers,
+                              std::cerr,
+                              inputImageFile.stem().string());
+#else
+          detection(fileInFolder.first, pipeId, imgGray, params, bank, markers, outputFile, inputImageFile.second.stem().string());
+#endif
+                    // if the original image is b/w convert it to BGRA so we can draw colors
+                    if(src.channels() == 1)
+                        cv::cvtColor(imgGray, src, cv::COLOR_GRAY2BGRA);
+
+                    drawMarkers(markers, src, cmdline._showUnreliableDetections);
+                    if(cmdline._saveDetectedImage)
+                    {
+                        // get the filename without extension and add the suffix
+                        auto saveFilename =
+                          bfs::path(inputImageFile.filename().stem().string() + detectedSuffix + subExt);
+                        if(!cmdline._outputFolderName.empty())
+                        {
+                            saveFilename = bfs::path(cmdline._outputFolderName) / saveFilename;
+                        }
+                        cv::imwrite(saveFilename.string(), src);
+                    }
+
+                    std::cerr << "Done processing image " << fileInFolder.second.string() << std::endl;
+                }
+            }
+        });
+    }
+    else
+    {
+        std::cerr << "The input file format is not supported" << std::endl;
+        throw std::logic_error("Unrecognized input.");
+    }
+    outputFile.close();
+    return EXIT_SUCCESS;
+}

--- a/src/cctag/cuda/frame.h
+++ b/src/cctag/cuda/frame.h
@@ -66,7 +66,7 @@ public:
         normalized_uchar_to_float
     };
 public:
-    FrameTexture( const cv::cuda::PtrStepSzb& plane );
+    explicit FrameTexture( const cv::cuda::PtrStepSzb& plane );
     ~FrameTexture( );
 
     inline cudaTextureObject_t getTex( ) {


### PR DESCRIPTION
Just small improvements to the detection app to be able to visualize the detected markers using opencv and optionally to save the result with the graphical overlay.

* it introduces the option `--save-detected-image` to save the images with the detected markers, displaying the ID and the outer ellipse.

* the option `--show-unreliable` is more for debugging purposes and allows to display the false detection as well

The graphical overlay looks like this (using images from ./sample):

![01_detected](https://user-images.githubusercontent.com/1331744/115121433-0d895b00-9fb3-11eb-9736-aff94d28dbcf.png)

![02_detected](https://user-images.githubusercontent.com/1331744/115121446-19751d00-9fb3-11eb-80c6-9c9b10659ea7.png)
