### PR TITLE
[debug] adapt VisualDebug for recent OpenCV

### DIFF
--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -236,7 +236,16 @@ int main(int argc, char** argv)
         // Read the parameter file provided by the user
         std::ifstream ifs(cmdline._paramsFilename);
         boost::archive::xml_iarchive ia(ifs);
-        ia >> boost::serialization::make_nvp("CCTagsParams", params);
+        try
+        {
+            ia >> boost::serialization::make_nvp("CCTagsParams", params);
+        }
+        catch(boost::archive::archive_exception& e)
+        {
+            std::cerr << std::endl << "Exception while reading parameter file: "
+                      << e.what() << std::endl;
+            return EXIT_FAILURE;
+        }
         CCTAG_COUT(params._nCrowns);
         CCTAG_COUT(nCrowns);
         if(nCrowns != params._nCrowns)

--- a/src/cctag/Params.cpp
+++ b/src/cctag/Params.cpp
@@ -79,6 +79,11 @@ Parameters::Parameters(std::size_t nCrowns)
     }
 }
 
+Parameters::~Parameters( )
+{
+    /* the default destructor does not prevent an unknown race condition on delete */
+}
+
 void Parameters::setDebugDir(const std::string& debugDir)
 {
     namespace fs = boost::filesystem;

--- a/src/cctag/Params.hpp
+++ b/src/cctag/Params.hpp
@@ -116,6 +116,8 @@ struct Parameters
      */
     explicit Parameters(std::size_t nCrowns = kDefaultNCrowns);
 
+    ~Parameters( );
+
     ///  canny low threshold
     float _cannyThrLow;
     ///  canny high threshold

--- a/src/cctag/utils/VisualDebug.cpp
+++ b/src/cctag/utils/VisualDebug.cpp
@@ -134,10 +134,12 @@ void CCTagVisualDebug::drawText(const cctag::Point2d<Eigen::Vector3f> & p, const
   CvFont font1;
   cvInitFont(&font1, CV_FONT_HERSHEY_SIMPLEX, 0.8, 0.8, 0, 2);
 
-  IplImage iplBack = _backImage;
-  cvPutText( &iplBack, text.c_str(),
-          cvPoint((int) p.x(), (int) p.y()),
-          &font1, CV_RGB(color[0] * 255, color[1] * 255, color[2] * 255));
+  auto clr = CV_RGB(color[0] * 255, color[1] * 255, color[2] * 255);
+  cv::Mat iplBack = _backImage;
+  cv::putText( iplBack, text.c_str(),
+               cvPoint((int) p.x(), (int) p.y()),
+               font1.font_face, font1.hscale,
+               clr );
 #endif
 }
 
@@ -262,10 +264,12 @@ void CCTagVisualDebug::drawInfos(const cctag::CCTag& marker, bool drawScaledMark
       y = int (marker.outerEllipse().center().y());
   }
 
-  IplImage iplImg = _backImage;
-  cvPutText( &iplImg, sId.c_str(),
-          cvPoint(x-10, y+10),
-          &font1, CV_RGB(255, 140, 0));
+  auto clr = CV_RGB(255, 140, 0);
+  cv::Mat iplImg = _backImage;
+  cv::putText( iplImg, sId.c_str(),
+               cvPoint(x-10, y+10),
+               font1.font_face, font1.hscale,
+               clr );
 #endif
 }
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Two minor fixes to make VisualDebug work with OpenCV 3.

VisualDebug creates image files of several intermediate results (more of those in CPU mode). Set CCTAG_VISUAL_DEBUG=on and CCTAG_SERIALIZE=on to activate.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
