### PR TITLE
Fix/deprecated boost timers

### DIFF
--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -236,7 +236,16 @@ int main(int argc, char** argv)
         // Read the parameter file provided by the user
         std::ifstream ifs(cmdline._paramsFilename);
         boost::archive::xml_iarchive ia(ifs);
-        ia >> boost::serialization::make_nvp("CCTagsParams", params);
+        try
+        {
+            ia >> boost::serialization::make_nvp("CCTagsParams", params);
+        }
+        catch(boost::archive::archive_exception& e)
+        {
+            std::cerr << std::endl << "Exception while reading parameter file: "
+                      << e.what() << std::endl;
+            return EXIT_FAILURE;
+        }
         CCTAG_COUT(params._nCrowns);
         CCTAG_COUT(nCrowns);
         if(nCrowns != params._nCrowns)

--- a/src/cctag/CCTag.cpp
+++ b/src/cctag/CCTag.cpp
@@ -18,7 +18,6 @@
 #include <opencv2/core/core_c.h>
 
 #include <boost/foreach.hpp>
-#include <boost/timer.hpp>
 #include <boost/array.hpp>
 #include <boost/mpl/bool.hpp>
 

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -34,7 +34,7 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/unordered/unordered_set.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <cmath>
@@ -584,7 +584,7 @@ void cctagDetectionFromEdges(
   createImageForVoteResultDebug(src, pyramidLevel);
 
   // Set some timers
-  boost::timer t3;
+  boost::timer::cpu_timer t3;
   boost::posix_time::ptime tstart0(boost::posix_time::microsec_clock::local_time());
 
   std::size_t nSegmentOut = 0;

--- a/src/cctag/Multiresolution.cpp
+++ b/src/cctag/Multiresolution.cpp
@@ -16,7 +16,7 @@
 #include <cctag/Detection.hpp>
 #include <cctag/utils/Talk.hpp> // for DO_TALK macro
 
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <cmath>

--- a/src/cctag/Params.cpp
+++ b/src/cctag/Params.cpp
@@ -79,6 +79,11 @@ Parameters::Parameters(std::size_t nCrowns)
     }
 }
 
+Parameters::~Parameters( )
+{
+    /* the default destructor does not prevent an unknown race condition on delete */
+}
+
 void Parameters::setDebugDir(const std::string& debugDir)
 {
     namespace fs = boost::filesystem;

--- a/src/cctag/Params.hpp
+++ b/src/cctag/Params.hpp
@@ -116,6 +116,8 @@ struct Parameters
      */
     explicit Parameters(std::size_t nCrowns = kDefaultNCrowns);
 
+    ~Parameters( );
+
     ///  canny low threshold
     float _cannyThrLow;
     ///  canny high threshold

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -29,7 +29,6 @@
 #include <boost/multi_array/subarray.hpp>
 #include <boost/container/flat_set.hpp>
 
-#include <boost/timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <deque>

--- a/src/cctag/cuda/tag.cu
+++ b/src/cctag/cuda/tag.cu
@@ -277,7 +277,7 @@ void TagPipe::imageCenterOptLoop(
                                  ellipse.angle() );
     float2 f = make_float2( center.x(), center.y() );
 
-    cctag::geometry::matrix3x3 bestHomography;
+    /* cctag::geometry::matrix3x3 bestHomography; */
 
     imageCenterOptLoop( tagIndex,
                         debug_numTags,

--- a/src/cctag/filter/cvRecode.cpp
+++ b/src/cctag/filter/cvRecode.cpp
@@ -18,7 +18,7 @@
 #include "cctag/Params.hpp"
 #include "cctag/utils/Talk.hpp" // do DO_TALK macro
 
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <cstdlib> // for ::abs
 #include <climits>
@@ -47,7 +47,7 @@ void cvRecodedCanny(
   int debug_info_level,
   const cctag::Parameters* params )
 {
-  boost::timer t;  
+  boost::timer::cpu_timer t;  
   std::vector<uchar*> stack;
   uchar** stack_top = nullptr, ** stack_bottom = nullptr;
   
@@ -166,8 +166,9 @@ void cvRecodedCanny(
 #define CANNY_PUSH( d )    *( d ) = (uchar)2, *stack_top++ = ( d )
 #define CANNY_POP( d )     ( d )  = *--stack_top
 
+  t.stop();
   DO_TALK( CCTAG_COUT_DEBUG( "Canny 1 took: " << t.elapsed() ); );
-  t.restart();
+  t.resume();
 
   // calculate magnitude and angle of gradient, perform non-maxima supression.
   // fill the map with one of the following values:
@@ -328,6 +329,7 @@ void cvRecodedCanny(
     mag_buf[2] = _mag;
   }
 
+  t.stop();
   DO_TALK( CCTAG_COUT_DEBUG( "Canny 2 took : " << t.elapsed() ); )
 
 #ifdef DEBUG_MAGMAP_BY_GRIFF
@@ -354,7 +356,7 @@ void cvRecodedCanny(
 	delete[] write_mag;
   }
 #endif // DEBUG_MAGMAP_BY_GRIFF
-  t.restart();
+  t.resume();
 
   // now track the edges (hysteresis thresholding)
   while( stack_top > stack_bottom )
@@ -389,9 +391,9 @@ void cvRecodedCanny(
       CANNY_PUSH( m + mapstep + 1 );
   }
 
+  t.stop();
   DO_TALK( CCTAG_COUT_DEBUG( "Canny 3 took : " << t.elapsed() ); )
-
-  t.restart();
+  t.resume();
 
   // the final pass, form the final image
   for( i = 0; i < size.height; i++ )

--- a/src/cctag/utils/VisualDebug.cpp
+++ b/src/cctag/utils/VisualDebug.cpp
@@ -134,10 +134,12 @@ void CCTagVisualDebug::drawText(const cctag::Point2d<Eigen::Vector3f> & p, const
   CvFont font1;
   cvInitFont(&font1, CV_FONT_HERSHEY_SIMPLEX, 0.8, 0.8, 0, 2);
 
-  IplImage iplBack = _backImage;
-  cvPutText( &iplBack, text.c_str(),
-          cvPoint((int) p.x(), (int) p.y()),
-          &font1, CV_RGB(color[0] * 255, color[1] * 255, color[2] * 255));
+  auto clr = CV_RGB(color[0] * 255, color[1] * 255, color[2] * 255);
+  cv::Mat iplBack = _backImage;
+  cv::putText( iplBack, text.c_str(),
+               cvPoint((int) p.x(), (int) p.y()),
+               font1.font_face, font1.hscale,
+               clr );
 #endif
 }
 
@@ -262,10 +264,12 @@ void CCTagVisualDebug::drawInfos(const cctag::CCTag& marker, bool drawScaledMark
       y = int (marker.outerEllipse().center().y());
   }
 
-  IplImage iplImg = _backImage;
-  cvPutText( &iplImg, sId.c_str(),
-          cvPoint(x-10, y+10),
-          &font1, CV_RGB(255, 140, 0));
+  auto clr = CV_RGB(255, 140, 0);
+  cv::Mat iplImg = _backImage;
+  cv::putText( iplImg, sId.c_str(),
+               cvPoint(x-10, y+10),
+               font1.font_face, font1.hscale,
+               clr );
 #endif
 }
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

No functional change. Deprecated boost timers may exist for a while longer, but fixing it now avoids a lot of meaningless warnings during compilation. The same with the unused variable.

Follow-up for PR #162 .

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
