### PR TITLE
MSVC build fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # build folder
-build
-build_*/
+build*/
+install*/
 # NetBeans project folder
 nbproject
 # Result of the sample code

--- a/src/cctag/Bresenham.cpp
+++ b/src/cctag/Bresenham.cpp
@@ -9,6 +9,7 @@
 #include <cctag/Bresenham.hpp>
 #include <cctag/utils/FileDebug.hpp>
 
+#include <boost/math/special_functions/sign.hpp>
 
 #include <cmath>
 


### PR DESCRIPTION
To avoid this error:
```
Bresenham.obj : error LNK2019: unresolved external symbol "int __cdecl boost::math::sign<int>(int const &)" (??$sign@H@math@boost@@YAHAEBH@Z) referenced in function "class cctag::EdgePoint * __cdecl cctag::gradientDirectionDescent(class
 cctag::EdgePointCollection const &,class cctag::EdgePoint const &,int,unsigned __int64,class cv::Mat const &,class cv::Mat const &,int)" (?gradientDirectionDescent@cctag@@YAPEAVEdgePoint@1@AEBVEdgePointCollection@1@AEBV21@H_KAEBVMat@cv
@@3H@Z) [D:\release\CCTag\build-bundle\src\CCTag.vcxproj]
Bresenham.obj : error LNK2019: unresolved external symbol "int __cdecl boost::math::sign<float>(float const &)" (??$sign@M@math@boost@@YAHAEBM@Z) referenced in function "class cctag::EdgePoint * __cdecl cctag::gradientDirectionDescent(c
lass cctag::EdgePointCollection const &,class cctag::EdgePoint const &,int,unsigned __int64,class cv::Mat const &,class cv::Mat const &,int)" (?gradientDirectionDescent@cctag@@YAPEAVEdgePoint@1@AEBVEdgePointCollection@1@AEBV21@H_KAEBVMa
t@cv@@3H@Z) [D:\release\CCTag\build-bundle\src\CCTag.vcxproj]
D:\release\CCTag\build-bundle\Windows-AMD64\Release\CCTag.dll : fatal error LNK1120: 2 unresolved externals [D:\release\CCTag\build-bundle\src\CCTag.vcxproj]
P
```
