### PR TITLE
Remove legacy defines for boost/cuda

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.0.1]
+
+### Changed
+
+- Renamed the marker files to be 0-based [PR](https://github.com/alicevision/CCTag/pull/165) 
+
+### Fixed
+
+- Fixed missing math module for boost [PR](https://github.com/alicevision/CCTag/pull/168)
+- Fixed compilation errors for newer version of boost on windows [PR](https://github.com/alicevision/CCTag/pull/166)
+- Removed old legacy defines for cuda and boost no more needed since the switch to c++14 [PR](https://github.com/alicevision/CCTag/pull/174)
+
+
 ## [1.0.0] - 2021-06-24
 
  - Support for OpenCV 3.4.9 [PR](https://github.com/alicevision/CCTag/pull/121)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [1.0.1]
+## [1.0.1] - 2021-10-08
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if(CCTAG_WITH_CUDA)
     set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
   endif()
 
-  find_package(CUDA 7.0 REQUIRED)
+  find_package(CUDA 9.0 REQUIRED)
 
   include(CheckNvccCompilerFlag)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.13)
 
 include(ExternalProject)
 
-project(CCTag VERSION 1.0.0 LANGUAGES C CXX)
+project(CCTag VERSION 1.0.1 LANGUAGES C CXX)
 
 # Set build path as a folder named as the platform (linux, windows, darwin...) plus the processor type
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")

--- a/src/cctag/cuda/cctag_cuda_runtime.h
+++ b/src/cctag/cuda/cctag_cuda_runtime.h
@@ -8,44 +8,4 @@
 
 #pragma once
 
-#ifdef __CUDACC__
- //
- // When compiling .cu files, there's a bunch of stuff that doesn't work with msvc:
- //
-#if defined(_MSC_VER)
-#  define BOOST_NO_CXX14_DIGIT_SEPARATORS
-#  define BOOST_NO_CXX11_UNICODE_LITERALS
-#  define BOOST_PP_VARIADICS 0
-#endif
-#  define BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
-#endif
-
 #include <cuda_runtime.h>
-
-
- // https://svn.boost.org/trac/boost/ticket/11897
- // This is fixed in 7.5. As the following version macro was introduced in 7.5 an existance
- // check is enough to detect versions < 7.5
- #if BOOST_CUDA_VERSION < 7050000
- #   define BOOST_NO_CXX11_VARIADIC_TEMPLATES
- #endif
- // The same bug is back again in 8.0:
- #if (BOOST_CUDA_VERSION > 8000000) && (BOOST_CUDA_VERSION < 8010000)
- #   define BOOST_NO_CXX11_VARIADIC_TEMPLATES
- #endif
- // Most recent CUDA (8.0) has no constexpr support in msvc mode:
- #if defined(_MSC_VER)
- #  define BOOST_NO_CXX11_CONSTEXPR
- #endif
-
-#ifdef __CUDACC__
-// And this one effects the NVCC front end,
-// See https://svn.boost.org/trac/boost/ticket/13049
-//
-#if (BOOST_CUDA_VERSION >= 8000000) && (BOOST_CUDA_VERSION < 8010000)
-#  define BOOST_NO_CXX11_NOEXCEPT
-#endif
-
-#endif
-
-


### PR DESCRIPTION
## Description

Since the switch to c++14 these defines are obsolete and some are not supported any more in the latest version of boost 1.76
