### PR TITLE
TBB:2021 oneAPI compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,9 @@ endif()
 # With MVSC, CMAKE_BUILD_TYPE will always be None, so TBB_USE_DEBUG_BUILD will always be false.
 string(COMPARE EQUAL "${CMAKE_BUILD_TYPE}" Debug TBB_USE_DEBUG_BUILD)
 find_package(TBB REQUIRED)
+if(TBB_VERSION VERSION_GREATER 2021.0.0)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 add_subdirectory(src)
 

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -97,6 +97,14 @@ if(NOT TBB_FOUND)
   endif()
   
   ##################################
+  # Try TBBConfig.cmake first
+  ##################################
+  find_package(TBB CONFIG)
+  if(TBB_FOUND)
+    return()
+  endif()
+  
+  ##################################
   # Set the TBB search directories
   ##################################
   

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -71,7 +71,11 @@ static void constructFlowComponentFromSeed(
         std::vector<CandidatePtr> & vCandidateLoopOne,
         const Parameters & params)
 {
+#if TBB_VERSION_MAJOR > 2020
+  static std::mutex G_SortMutex;
+#else
   static tbb::mutex G_SortMutex;
+#endif
   
   assert( seed );
   // Check if the seed has already been processed, i.e. belongs to an already
@@ -102,7 +106,11 @@ static void constructFlowComponentFromSeed(
     }
     
     {
+#if TBB_VERSION_MAJOR > 2020
+      std::scoped_lock lock(G_SortMutex);
+#else
       tbb::mutex::scoped_lock lock(G_SortMutex);
+#endif
       candidate->_averageReceivedVote = (float) (nReceivedVote*nReceivedVote) / (float) nVotedPoints;
       auto it = std::lower_bound(vCandidateLoopOne.begin(), vCandidateLoopOne.end(), candidate,
         [](const CandidatePtr& c1, const CandidatePtr& c2) { return c1->_averageReceivedVote > c2->_averageReceivedVote; });
@@ -120,7 +128,11 @@ static void completeFlowComponent(
   const Parameters & params)
 {
   static tbb::spin_mutex G_UpdateMutex;
+#if TBB_VERSION_MAJOR > 2020
+  static std::mutex G_InsertMutex;
+#else
   static tbb::mutex G_InsertMutex;
+#endif
   
   try
   {
@@ -239,7 +251,11 @@ static void completeFlowComponent(
     }
 
     {
+#if TBB_VERSION_MAJOR > 2020
+      std::scoped_lock lock(G_InsertMutex);
+#else
       tbb::mutex::scoped_lock lock(G_InsertMutex);
+#endif
       vCandidateLoopTwo.push_back(candidate);
     }
 
@@ -384,7 +400,11 @@ static void cctagDetectionFromEdgesLoopTwoIteration(
   float scale,
   const Parameters& params)
 {
+#if TBB_VERSION_MAJOR > 2020
+    static std::mutex G_InsertMutex;
+#else
     static tbb::mutex G_InsertMutex;
+#endif
     
     const Candidate& candidate = vCandidateLoopTwo[iCandidate];
 
@@ -543,7 +563,11 @@ static void cctagDetectionFromEdgesLoopTwoIteration(
 #endif
       
       {
+#if TBB_VERSION_MAJOR > 2020
+        std::scoped_lock lock(G_InsertMutex);
+#else
         tbb::mutex::scoped_lock lock(G_InsertMutex);
+#endif
         markers.push_back( tag ); // markers takes responsibility for delete
       }
 #ifdef CCTAG_SERIALIZE

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -71,7 +71,11 @@ bool orazioDistanceRobust(
 #endif // GRIFF_DEBUG
   
   const size_t cut_count = cuts.size();
+#if TBB_VERSION_MAJOR > 2020
+  static std::mutex vscore_mutex;
+#else
   static tbb::mutex vscore_mutex;
+#endif
 
   tbb::parallel_for(size_t(0), cut_count, [&](size_t i) {
     const cctag::ImageCut& cut = cuts[i];
@@ -183,7 +187,11 @@ bool orazioDistanceRobust(
   #endif // GRIFF_DEBUG
 
       {
+#if TBB_VERSION_MAJOR > 2020
+        std::scoped_lock lock(vscore_mutex);
+#else
         tbb::mutex::scoped_lock lock(vscore_mutex);
+#endif
         vScore[idSet.front().first].push_back(idSet.front().second);
       }
     }


### PR DESCRIPTION
## Description: TBB:2021 compatibility fix

## Implementation remarks
- [x] replace `tbb::mutex` with `std::mutex`
- [x] replace `tbb::mutex::scoped_lock` with `std::scoped_lock`
- [x] bump to `cpp17` if `tbb>2020`
- [x] use cmake config to find `tbb:2021` in `FindTBB.cmake`

Fix #177 