### PR TITLE
fix gcc11 ordered pointer comparison

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- fix gcc11 ordered pointer comparison [PR](https://github.com/alicevision/CCTag/pull/191)
 
 ### Removed
 

--- a/src/cctag/cuda/frame_export.cu
+++ b/src/cctag/cuda/frame_export.cu
@@ -102,12 +102,12 @@ bool Frame::applyExport( cctag::EdgePointCollection& out_edges,
 
         if( pt.descending.after.x != 0 || pt.descending.after.y != 0 ) {
             cctag::EdgePoint* n = out_edges(pt.descending.after.x, pt.descending.after.y);
-            if( n >= 0 )
+            if( n )
                 out_edges.set_after(ep, out_edges(n));
         }
         if( pt.descending.befor.x != 0 || pt.descending.befor.y != 0 ) {
             cctag::EdgePoint* n = out_edges(pt.descending.befor.x, pt.descending.befor.y);
-            if( n >= 0 )
+            if( n )
                 out_edges.set_before(ep, out_edges(n));
         }
 


### PR DESCRIPTION
cuda:11 with gcc:11 host compiler complains about: ordered comparison of pointer with int zero.
```cpp
/build/cctag/src/CCTag-1.0.1/src/./cctag/cuda/frame_export.cu: In member function ‘bool cctag::Frame::applyExport(cctag::EdgePointCollection&, std::vector<cct
ag::EdgePoint*>&, int)’:
/build/cctag/src/CCTag-1.0.1/src/./cctag/cuda/frame_export.cu:105:7: error: ordered comparison of pointer with integer zero (‘cctag::EdgePoint*’ and ‘int’)
  105 |             if( n >= 0 )
      |       ^
/build/cctag/src/CCTag-1.0.1/src/./cctag/cuda/frame_export.cu:110:7: error: ordered comparison of pointer with integer zero (‘cctag::EdgePoint*’ and ‘int’)
  110 |             if( n >= 0 )
      |       ^
CMake Error at CCTag_generated_frame_export.cu.o.Release.cmake:280 (message):
  Error generating file
  /build/cctag/src/build/src/CMakeFiles/CCTag.dir/./cctag/cuda/./CCTag_generated_frame_export.cu.o
```