### PR TITLE
[cmake] Fix handling of BUILD_SHARED_LIBS option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix gcc11 ordered pointer comparison [PR](https://github.com/alicevision/CCTag/pull/191)
+- fix handling of BUILD_SHARED_LIBS option [PR](https://github.com/alicevision/CCTag/pull/201)
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(CCTAG_ENABLE_SIMD_AVX2 "Enable AVX2 optimizations" OFF)
 option(CCTAG_BUILD_TESTS "Build the unity tests" ON)
 option(CCTAG_BUILD_DOC "Build documentation" OFF)
 option(CCTAG_NO_THRUST_COPY_IF "Do not use thrust::copy_if() on GPU. There may be a bug on CUDA 7 with GTX 980, 980Ti and 1080" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -8,10 +8,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 
   set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
 
-# if this is used as a stand-alone project we need to tell whether to use PIC
-if(NOT DEFINED BUILD_SHARED_LIBS)
+  # if this is used as a stand-alone project we need to tell whether to use PIC
   option(BUILD_SHARED_LIBS "Build shared libraries" ON)
   set(CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 endif()


### PR DESCRIPTION
BUILD_SHARED_LIBS option is declared conditionally on whether BUILD_SHARED_LIBS is defined itself. This is problematic as multiple invocations of a build runner such as ninja will cause builds to use different options. The first build will run as if BUILD_SHARED_LIBS is not defined (i.e. OFF option), the second time cmake will notice that BUILD_SHARED_LIBS was defined after all and now run build with BUILD_SHARED_LIBS set to ON. This is confusing and error prone.

To fix the problem, a top-level BUILD_SHARED_LIBS option has been added and BUILD_SHARED_LIBS option in applications subdirectory was changed to become active only if the project is standalone.

