### PR TITLE
[fixes] Boost fixes for versions >=1.85

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,14 +2,14 @@ name: Continuous Integration
 
 on:
   push:
-    branches:
-      - master
-      - develop
+#    branches:
+#      - master
+#      - develop
     # Skip jobs when only documentation files are changed
-    paths-ignore:
-      - '**.md'
-      - '**.rst'
-      - 'docs/**'
+#    paths-ignore:
+#      - '**.md'
+#      - '**.rst'
+#      - 'docs/**'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -17,7 +17,7 @@ on:
       - 'docs/**'
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,3 +68,83 @@ jobs:
            -DBUILD_SHARED_LIBS:BOOL=ON \
            -DCMAKE_PREFIX_PATH:PATH="$PWD/../../cctag_install;${DEPS_INSTALL_DIR}"
           make -j8
+
+  build_windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        config: [ Debug, Release ]
+    env:
+      buildDir: '${{ github.workspace }}\build\'
+      vcpkgDir: '${{ github.workspace }}\..\e\vcpkg'
+      # commit for version 2023.11.20
+      COMMIT_ID: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install latest CMake.
+      uses: lukka/get-cmake@latest
+
+    # Restore from cache the previously built ports. If a "cache miss" occurs, then vcpkg is bootstrapped. Since a the vcpkg.json is being used later on to install the packages when run-cmake runs, no packages are installed at this time and the input 'setupOnly:true' is mandatory.
+    - name: vcpkg - Setup dependencies
+      uses: lukka/run-vcpkg@v7
+      with:
+        # Just install vcpkg for now, do not install any ports in this step yet.
+        setupOnly: false
+        # Location of the vcpkg submodule in the Git repository.
+        vcpkgDirectory: ${{ env.vcpkgDir }}
+        vcpkgGitCommitId: ${{ env.COMMIT_ID }}
+        vcpkgArguments: >
+          boost-accumulators 
+          boost-algorithm boost-container
+          boost-date-time
+          boost-exception
+          boost-filesystem
+          boost-foreach
+          boost-iterator
+          boost-lexical-cast
+          boost-math
+          boost-mpl
+          boost-multi-array
+          boost-ptr-container
+          boost-program-options
+          boost-serialization
+          boost-spirit
+          boost-static-assert
+          boost-stacktrace
+          boost-test
+          boost-thread
+          boost-throw-exception
+          boost-timer
+          boost-type-traits
+          boost-unordered
+          opencv
+          tbb
+          eigen3
+        vcpkgTriplet: x64-windows
+        # doNotCache: true
+        # This is used to unbreak cached artifacts if for some reason dependencies fail to build,
+        # the action does not notice it and saves broken artifacts.
+        appendedCacheKey: cache007
+
+    - name: vcpkg - Display installed packages
+      run:
+          ${{ env.vcpkgDir }}\vcpkg.exe list
+
+    - name: Build
+      uses: lukka/run-cmake@v3
+      with:
+        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+        cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+        buildDirectory: ${{ env.buildDir }}
+#        cmakeGenerator: VS16Win64
+        cmakeAppendedArgs: -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DVCPKG_TARGET_TRIPLET=x64-windows -A x64 -T host=x64 -DCCTAG_WITH_CUDA:BOOL=OFF
+        # This input tells run-cmake to consume the vcpkg.cmake toolchain file set by run-vcpkg.
+        cmakeBuildType: ${{ matrix.config }}
+        useVcpkgToolchainFile: true
+        buildWithCMake: true
+        buildWithCMakeArgs: -j1 --config ${{ matrix.config }}

--- a/doc/sphinx/source/install/install.rst
+++ b/doc/sphinx/source/install/install.rst
@@ -120,6 +120,7 @@ To install the dependencies:
           boost-container
           boost-date-time
           boost-exception
+          boost-foreach
           boost-filesystem
           boost-iterator
           boost-lexical-cast
@@ -141,6 +142,8 @@ To install the dependencies:
           opencv
           tbb
           eigen3
+
+Note that for boost >= 1.85 you have to use :code:`math[legacy]`.
 
 You can add the flag :code:`--triplet` to specify the architecture and the version you want to build.
 For example:

--- a/src/applications/detection/main.cpp
+++ b/src/applications/detection/main.cpp
@@ -21,7 +21,6 @@
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/exception/all.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/ptr_container/ptr_list.hpp>
 #include <boost/timer/timer.hpp>
 #include <opencv2/core/core.hpp>
@@ -501,7 +500,7 @@ int main(int argc, char** argv)
         tbb::parallel_for(0, 2, [&](size_t fileListIdx) {
             for(const auto& fileInFolder : files[fileListIdx])
             {
-                const std::string subExt(bfs::extension(fileInFolder.second));
+                const std::string subExt(fileInFolder.second.extension().string());
 
                 if((subExt == ".png") || (subExt == ".jpg") || (subExt == ".PNG") || (subExt == ".JPG"))
                 {

--- a/src/cctag/CCTag.cpp
+++ b/src/cctag/CCTag.cpp
@@ -17,7 +17,6 @@
 
 #include <opencv2/core/core_c.h>
 
-#include <boost/foreach.hpp>
 #include <boost/array.hpp>
 #include <boost/mpl/bool.hpp>
 

--- a/src/cctag/CCTagFlowComponent.cpp
+++ b/src/cctag/CCTagFlowComponent.cpp
@@ -8,7 +8,6 @@
 #include <cctag/CCTagFlowComponent.hpp>
 #include <cctag/utils/Defines.hpp>
 
-#include <boost/foreach.hpp>
 
 namespace cctag
 {

--- a/src/cctag/DataSerialization.hpp
+++ b/src/cctag/DataSerialization.hpp
@@ -15,7 +15,6 @@
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/archive/text_oarchive.hpp>
-#include <boost/foreach.hpp>
 
 namespace cctag {
 

--- a/src/cctag/Detection.cpp
+++ b/src/cctag/Detection.cpp
@@ -28,7 +28,6 @@
 #include "cctag/cuda/tag.h"
 #endif
 
-#include <boost/foreach.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/mpl/bool.hpp>

--- a/src/cctag/EllipseGrowing.cpp
+++ b/src/cctag/EllipseGrowing.cpp
@@ -23,7 +23,6 @@
 #include <opencv2/core/types_c.h>
 
 #include <boost/math/special_functions/pow.hpp>
-#include <boost/foreach.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/assert.hpp>

--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -225,8 +225,6 @@ template void fitEllipse(std::vector<cctag::Point2d<Eigen::Vector3f>>::const_ite
 } // geometry
 
 float innerProdMin(const std::vector<cctag::EdgePoint*>& filteredChildren, float thrCosDiffMax, Point2d<Vector3s> & p1, Point2d<Vector3s> & p2) {
-            using namespace boost::numeric;
-            //using namespace cctag::numerical;
 
             EdgePoint* pAngle1 = nullptr;
             EdgePoint* pAngle2 = nullptr;
@@ -334,7 +332,6 @@ void ellipseFitting( cctag::numerical::geometry::Ellipse& e, const std::vector<c
 }
 
 void circleFitting(cctag::numerical::geometry::Ellipse& e, const std::vector<cctag::EdgePoint*>& points) {
-  using namespace boost::numeric;
 
   std::size_t nPoints = points.size();
 

--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -7,7 +7,6 @@
  */
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/round.hpp>

--- a/src/cctag/Fitting.hpp
+++ b/src/cctag/Fitting.hpp
@@ -11,7 +11,6 @@
 #include <cctag/EdgePoint.hpp>
 #include <cctag/geometry/Ellipse.hpp>
 #include <cctag/geometry/Point.hpp>
-#include <boost/foreach.hpp>
 
 #include <list>
 #include <string>

--- a/src/cctag/ICCTag.cpp
+++ b/src/cctag/ICCTag.cpp
@@ -10,7 +10,6 @@
 #include <cctag/Detection.hpp>
 #include <cctag/utils/LogTime.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -571,9 +571,7 @@ void selectCutCheapUniform( std::vector< cctag::ImageCut > & vSelectedCuts,
   
   vSelectedCuts.clear();
   vSelectedCuts.reserve(selectSize);
-  
-  std::size_t sharpSize = 0;
-  
+
   // Initialize vector of indices of sharp cuts
   std::vector<std::size_t> indToAdd;
   indToAdd.reserve(varCuts.size());

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -699,7 +699,7 @@ std::pair<float,float> convImageCut(const std::vector<float> & kernel, ImageCut 
   //cut.imgSignal() = output;
   
   // Locate the maximum value.
-  std::vector<float>::iterator maxValueIt = std::max_element(output.begin(), output.end());
+  auto maxValueIt = std::max_element(output.begin(), output.end());
   float itsLocation = (float) std::distance(output.begin(), maxValueIt);
   
   //CCTAG_COUT_VAR2(*maxValueIt, itsLocation);

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -703,8 +703,9 @@ std::pair<float,float> convImageCut(const std::vector<float> & kernel, ImageCut 
   float itsLocation = (float) std::distance(output.begin(), maxValueIt);
   
   //CCTAG_COUT_VAR2(*maxValueIt, itsLocation);
-  
-  return std::pair<float,float>(*maxValueIt,itsLocation);// max value, its location
+
+  // max value, its location
+  return {*maxValueIt, itsLocation};
 }
 
 /**

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -61,7 +61,7 @@ bool orazioDistanceRobust(
 
   using MapT = std::map<float, MarkerID>;
 
-  if ( cuts.size() == 0 )
+  if ( cuts.empty() )
   {
     return false;
   }
@@ -1262,7 +1262,7 @@ int identify_step_1(
   )
 #endif
 
-  if ( cuts.size() == 0 )
+  if ( cuts.empty() )
   {
     // Can happen when an object or the image frame is occluding a part of all available cuts.
     return status::no_collected_cuts;
@@ -1288,7 +1288,7 @@ int identify_step_1(
     const float spendTime = d.total_milliseconds();
   }
 
-  if ( vSelectedCuts.size() == 0 )
+  if ( vSelectedCuts.empty() )
   {
     CCTAG_COUT_DEBUG("Unable to select any cut.");
     return status::no_selected_cuts; // todo: is class attributes the best option?

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -26,6 +26,7 @@
 #include <boost/accumulators/statistics/median.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/assert.hpp>
+#include <boost/foreach.hpp>
 
 #include <cmath>
 #include <mutex>

--- a/src/cctag/Identification.hpp
+++ b/src/cctag/Identification.hpp
@@ -16,9 +16,7 @@
 
 #include <opencv2/opencv.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/accumulators/statistics/median.hpp>
-#include <boost/foreach.hpp>
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 

--- a/src/cctag/Vote.cpp
+++ b/src/cctag/Vote.cpp
@@ -20,7 +20,6 @@
 #include <cctag/utils/Defines.hpp>
 #include <cctag/utils/VisualDebug.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/special_functions/log1p.hpp>

--- a/src/cctag/optimization/conditioner.hpp
+++ b/src/cctag/optimization/conditioner.hpp
@@ -12,9 +12,6 @@
 #include <cctag/Statistic.hpp>
 #include <cctag/geometry/Ellipse.hpp>
 
-#include <boost/foreach.hpp>
-
-
 namespace cctag {
 namespace numerical {
 namespace optimization {


### PR DESCRIPTION
Several fixes that remove old unused stuff and makes code compatible with boost versions >=1.85

* Remove all includes of boost foreach that were not previously removed (fixes #216 )
   * specify in the documentation that boost-foreach is a dependency to install in vcpkg
* Remove unused `using boost::numeric`
* use `path.extension()` as `bfs::extension()` has been removed in 1.85 (deprecated long time ago) (fixes #217 )

Incidentally
* add an initial github CI pipeline for Windows without CUDA
   * note that if we need to switch to a more recent version of vcpkg with boost  >=1.85 we need to specify `boost-math[legacy]` to be able to get `boost_math_c99`