### PR TITLE
raise MAX_RESOLUTION to 8192

### DIFF
--- a/src/cctag/Types.hpp
+++ b/src/cctag/Types.hpp
@@ -21,7 +21,7 @@ class EdgePointCollection
 public:
   static constexpr size_t MAX_POINTS = size_t(1) << 24;
 private:
-  static constexpr size_t MAX_RESOLUTION = 6144;
+  static constexpr size_t MAX_RESOLUTION = 8192;
   static constexpr size_t CUDA_OFFSET = 1024; // 4 kB, one page
   static constexpr size_t MAX_VOTERLIST_SIZE = 16*MAX_POINTS;
   


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Using 40Mp pictures from an action cam raised the following issue during cctag recognition:

`EdgePointCollection::set_frame_size: image resolution is too large`

This PR tries to raise the hard-coded limit value to 8192 (67Mp)
