### PR TITLE
[PATCH] Remove Boost.Foreach dependency from project

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,7 +107,6 @@ jobs:
           boost-date-time
           boost-exception
           boost-filesystem
-          boost-foreach
           boost-iterator
           boost-lexical-cast
           boost-math[legacy]

--- a/doc/sphinx/source/install/install.rst
+++ b/doc/sphinx/source/install/install.rst
@@ -120,7 +120,6 @@ To install the dependencies:
           boost-container
           boost-date-time
           boost-exception
-          boost-foreach
           boost-filesystem
           boost-iterator
           boost-lexical-cast

--- a/src/cctag/Identification.cpp
+++ b/src/cctag/Identification.cpp
@@ -26,7 +26,6 @@
 #include <boost/accumulators/statistics/median.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/assert.hpp>
-#include <boost/foreach.hpp>
 
 #include <cmath>
 #include <mutex>
@@ -167,13 +166,10 @@ bool orazioDistanceRobust(
       assert( sortedId.size() > 0 );
   #endif // GRIFF_DEBUG
       int k = 0;
-      BOOST_REVERSE_FOREACH( const MapT::const_iterator::value_type & v, sortedId )
+      for( auto riter = sortedId.crbegin(); riter != sortedId.crend(); ++riter )
       {
         if( k >= sizeIds ) break;
-        std::pair< MarkerID, float > markerId;
-        markerId.first = v.second;
-        markerId.second = v.first;
-        idSet.push_back(markerId);
+        idSet.emplace_back(riter->second, riter->first);
         ++k;
       }
 


### PR DESCRIPTION
Since we build with C++14, we can use a `std::const_reverse_iterator` for the `std::map` instead of the `BOOST_REVERSE_FOREACH` macro.

Also use `std::vector::emplace_back` to construct the new `std::pair` in-place, which eliminates an unnecessary copy/temporary.

This removes all usages of Boost.Foreach from the project, making it no longer a required dependency.