### PR TITLE
[FIX] Handle endianness check for MSVC ARM[64]

### DIFF
--- a/src/cctag/utils/pcg_uint128.hpp
+++ b/src/cctag/utils/pcg_uint128.hpp
@@ -72,8 +72,10 @@
     #elif __powerpc__ || __POWERPC__ || __ppc__ || __PPC__ \
           || __m68k__ || __mc68000__
         #define PCG_LITTLE_ENDIAN 0
+    #elif _M_ARM || _M_ARM64 || _M_ARM64EC  // MSVC ARM Support
+        #define PCG_LITTLE_ENDIAN 1
     #else
-        #error Unable to determine target endianness
+        #error Unable to determine target endianness, please file a bug report
     #endif
 #endif
 


### PR DESCRIPTION
This patch adds support for detecting the target endianness required for `pcg_uint128.hpp` when compiling with MSVC and targeting ARM architectures.

Windows on ARM requires code to be compiled in little-endian (see the [Microsoft Documentation](https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/arm64-windows-abi-conventions.md#endianness)).

This enables compiling CCTag on Windows on ARM.