### PR TITLE
Fix issue with auto and eigen return type 

### DIFF
--- a/src/cctag/Fitting.cpp
+++ b/src/cctag/Fitting.cpp
@@ -124,7 +124,7 @@ static Conic fit_solver(It begin, It end)
   EigenSolver<Matrix3f> M_ev(M);
   Vector3f cond;
   {
-    const auto evr = M_ev.eigenvectors().real().array();
+    const Array33f evr = M_ev.eigenvectors().real().array();
     cond = 4*evr.row(0)*evr.row(2) - evr.row(1)*evr.row(1);
   }
 


### PR DESCRIPTION
A problem with deducing the proper return type for eigen was detected in #219. In #226 also it shows that this affects the markers detection on some platforms.