### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,11 @@
 
 name: Mark stale issues and pull requests
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/alicevision/CCTag/security/code-scanning/1](https://github.com/alicevision/CCTag/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/stale.yml` so the workflow only gets the scopes needed by `actions/stale`.  
Best single fix without changing behavior: define permissions at the workflow root (applies to all jobs), granting:
- `contents: write`
- `issues: write`
- `pull-requests: write`

This matches the CodeQL minimal starting point for stale automation that updates issues/PRs and keeps functionality intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
